### PR TITLE
prevent TableMapEventData hash from growing unbounded.

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/LRUCache.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/LRUCache.java
@@ -1,0 +1,19 @@
+package com.github.shyiko.mysql.binlog.event;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LRUCache<K,V> extends LinkedHashMap<K,V> {
+    private int maxSize;
+
+    // and other constructors for load factor and hashtable capacity
+    public LRUCache(int initialCapacity, float loadFactor, int maxSize) {
+        super(initialCapacity, loadFactor, true);
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        return size() > maxSize;
+    }
+}

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
@@ -20,6 +20,7 @@ import com.github.shyiko.mysql.binlog.event.EventData;
 import com.github.shyiko.mysql.binlog.event.EventHeader;
 import com.github.shyiko.mysql.binlog.event.EventType;
 import com.github.shyiko.mysql.binlog.event.FormatDescriptionEventData;
+import com.github.shyiko.mysql.binlog.event.LRUCache;
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
 import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 
@@ -65,7 +66,7 @@ public class EventDeserializer {
         this.eventHeaderDeserializer = eventHeaderDeserializer;
         this.defaultEventDataDeserializer = defaultEventDataDeserializer;
         this.eventDataDeserializers = new IdentityHashMap<EventType, EventDataDeserializer>();
-        this.tableMapEventByTableId = new HashMap<Long, TableMapEventData>();
+        this.tableMapEventByTableId = new LRUCache<>(100, 0.75f, 10000);
         registerDefaultEventDataDeserializers();
         afterEventDataDeserializerSet(null);
     }


### PR DESCRIPTION
see https://github.com/zendesk/maxwell/issues/1468 for the full story.
I'm not even sure how big this LRUCache really needs to be, given that
we unconditionally put stuff in it before every transaction.  I think
the size might need to be 1?  Unclear.