### PR TITLE
Propagate all exceptions that occur in connectTimeout thread

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -495,8 +495,9 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
      * @throws AuthenticationException if authentication fails
      * @throws ServerException if MySQL server responds with an error
      * @throws IOException if anything goes wrong while trying to connect
+     * @throws IllegalStateException if binary log client is already connected
      */
-    public void connect() throws IOException {
+    public void connect() throws IOException, IllegalStateException {
         if (!connectLock.tryLock()) {
             throw new IllegalStateException("BinaryLogClient is already connected");
         }
@@ -836,8 +837,8 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                 try {
                     setConnectTimeout(timeout);
                     connect();
-                } catch (IOException e) {
-                    exceptionReference.set(e);
+                } catch (Exception e) {
+                    exceptionReference.set(new IOException(e)); // method is asynchronous, catch all exceptions so that they are not lost
                     countDownLatch.countDown(); // making sure we don't end up waiting whole "timeout"
                 }
             }

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
@@ -833,6 +833,12 @@ public class BinaryLogClientIntegrationTest {
         client.connect();
     }
 
+    @Test(expectedExceptions = IOException.class)
+    public void testExceptionIsThrownWhenTryingToConnectAlreadyConnectedClientWithTimeout() throws Exception {
+        assertTrue(client.isConnected());
+        client.connect(1000);
+    }
+
     @Test
     public void testExceptionIsThrownWhenProvidedWithWrongCredentials() throws Exception {
         BinaryLogClient binaryLogClient =


### PR DESCRIPTION
I experience an issue on production for maxwell, where an exception occurred during connection to a database that had experienced many failovers. However the exception was uncaught, and our maxwell container continued to operate in a bad state.

Going through the code here, it looks like only IOExceptions were caught by the code, causing the IllegalStateException thrown when there is already a connection to fall through the cracks. Here we force all exceptions to propagate out, and successfully terminate the application when one occurs.