### PR TITLE
fixed auth exception test

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -837,6 +837,9 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                 try {
                     setConnectTimeout(timeout);
                     connect();
+                } catch (IOException e) {
+                    exceptionReference.set(e);
+                    countDownLatch.countDown(); // making sure we don't end up waiting whole "timeout"
                 } catch (Exception e) {
                     exceptionReference.set(new IOException(e)); // method is asynchronous, catch all exceptions so that they are not lost
                     countDownLatch.countDown(); // making sure we don't end up waiting whole "timeout"


### PR DESCRIPTION
It looks like AuthenticationException was a subclass of IOException, which is why most errors were able to be caught originally.

This PR changes the exception handling so that only non-IOExceptions are recast as IOExceptions.