### PR TITLE
Add option to parse integer as byte array

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/AbstractRowsEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/AbstractRowsEventDataDeserializer.java
@@ -75,6 +75,7 @@ public abstract class AbstractRowsEventDataDeserializer<T extends EventData> imp
     private Long invalidDateAndTimeRepresentation;
     private boolean microsecondsPrecision;
     private boolean deserializeCharAndBinaryAsByteArray;
+    private boolean deserializeIntegerAsByteArray;
 
     public AbstractRowsEventDataDeserializer(Map<Long, TableMapEventData> tableMapEventByTableId) {
         this.tableMapEventByTableId = tableMapEventByTableId;
@@ -95,6 +96,10 @@ public abstract class AbstractRowsEventDataDeserializer<T extends EventData> imp
 
     void setDeserializeCharAndBinaryAsByteArray(boolean value) {
         this.deserializeCharAndBinaryAsByteArray = value;
+    }
+
+    void setDeserializeIntegerAsByteArray(boolean deserializeIntegerAsByteArray) {
+        this.deserializeIntegerAsByteArray = deserializeIntegerAsByteArray;
     }
 
     protected Serializable[] deserializeRow(long tableId, BitSet includedColumns, ByteArrayInputStream inputStream)
@@ -203,22 +208,37 @@ public abstract class AbstractRowsEventDataDeserializer<T extends EventData> imp
     }
 
     protected Serializable deserializeTiny(ByteArrayInputStream inputStream) throws IOException {
+        if (deserializeIntegerAsByteArray) {
+            return inputStream.read(1);
+        }
         return (int) ((byte) inputStream.readInteger(1));
     }
 
     protected Serializable deserializeShort(ByteArrayInputStream inputStream) throws IOException {
+        if (deserializeIntegerAsByteArray) {
+            return inputStream.read(2);
+        }
         return (int) ((short) inputStream.readInteger(2));
     }
 
     protected Serializable deserializeInt24(ByteArrayInputStream inputStream) throws IOException {
+        if (deserializeIntegerAsByteArray) {
+            return inputStream.read(3);
+        }
         return (inputStream.readInteger(3) << 8) >> 8;
     }
 
     protected Serializable deserializeLong(ByteArrayInputStream inputStream) throws IOException {
+        if (deserializeIntegerAsByteArray) {
+            return inputStream.read(4);
+        }
         return inputStream.readInteger(4);
     }
 
     protected Serializable deserializeLongLong(ByteArrayInputStream inputStream) throws IOException {
+        if (deserializeIntegerAsByteArray) {
+            return inputStream.read(8);
+        }
         return inputStream.readLong(8);
     }
 

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
@@ -200,6 +200,9 @@ public class EventDeserializer {
             deserializer.setDeserializeCharAndBinaryAsByteArray(
                 compatibilitySet.contains(CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY)
             );
+            deserializer.setDeserializeIntegerAsByteArray(
+                compatibilitySet.contains(CompatibilityMode.INTEGER_AS_BYTE_ARRAY)
+            );
         }
     }
 
@@ -350,7 +353,11 @@ public class EventDeserializer {
          *
          * <p>This option is going to be enabled by default starting from mysql-binlog-connector-java@1.0.0.
          */
-        CHAR_AND_BINARY_AS_BYTE_ARRAY
+        CHAR_AND_BINARY_AS_BYTE_ARRAY,
+        /**
+         * Return TINY/SHORT/INT24/LONG/LONGLONG values as byte[]|s (instead of int|s).
+         */
+        INTEGER_AS_BYTE_ARRAY
     }
 
     /**

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
@@ -422,6 +422,44 @@ public class BinaryLogClientIntegrationTest {
     }
 
     @Test
+    public void testDeserializationOfIntegerAsByteArray() throws Exception {
+        final BinaryLogClient client = new BinaryLogClient(slave.hostname, slave.port,
+            slave.username, slave.password);
+        EventDeserializer eventDeserializer = new EventDeserializer();
+        eventDeserializer.setCompatibilityMode(CompatibilityMode.INTEGER_AS_BYTE_ARRAY);
+        client.setEventDeserializer(eventDeserializer);
+        client.connect(DEFAULT_TIMEOUT);
+        try {
+            assertEquals(writeAndCaptureRow("tinyint unsigned", "0", "1", "255"),
+                new Serializable[]{new byte[]{0}, new byte[]{1}, new byte[]{-1}});
+            assertEquals(writeAndCaptureRow("tinyint", "-128", "-1", "0", "1", "127"),
+                new Serializable[]{new byte[]{-0x80}, new byte[]{-1}, new byte[]{0}, new byte[]{1}, new byte[]{0x7f}});
+
+            assertEquals(writeAndCaptureRow("smallint unsigned", "0", "1", "65535"),
+                new Serializable[]{new byte[]{0, 0}, new byte[]{0, 1}, new byte[]{-1, -1}});
+            assertEquals(writeAndCaptureRow("smallint", "-32768", "-1", "0", "1", "32767"),
+                new Serializable[]{new byte[]{-0x80, 0}, new byte[]{-1, -1}, new byte[]{0, 0}, new byte[]{0, 1}, new byte[]{0x7f, -1}});
+
+            assertEquals(writeAndCaptureRow("mediumint unsigned", "0", "1", "16777215"),
+                new Serializable[]{new byte[]{0, 0, 0}, new byte[]{0, 0, 1}, new byte[]{-1, -1, -1}});
+            assertEquals(writeAndCaptureRow("mediumint", "-8388608", "-1", "0", "1", "8388607"),
+                new Serializable[]{new byte[]{-0x80, 0, 0}, new byte[]{-1, -1, -1}, new byte[]{0, 0, 0}, new byte[]{0, 0, 1}, new byte[]{0x7f, -1, -1}});
+
+            assertEquals(writeAndCaptureRow("int unsigned", "0", "1", "4294967295"),
+                new Serializable[]{new byte[]{0, 0, 0, 0}, new byte[]{0, 0, 0, 1}, new byte[]{-1, -1, -1, -1}});
+            assertEquals(writeAndCaptureRow("int", "-2147483648", "-1", "0", "1", "2147483647"),
+                new Serializable[]{new byte[]{-0x80, 0, 0, 0}, new byte[]{-1, -1, -1, -1}, new byte[]{0, 0, 0, 0}, new byte[]{0, 0, 0, 1}, new byte[]{0x7f, -1, -1, -1}});
+
+            assertEquals(writeAndCaptureRow("bigint unsigned", "0", "1", "18446744073709551615"),
+                new Serializable[]{new byte[]{0, 0, 0, 0, 0, 0, 0, 0}, new byte[]{0, 0, 0, 0, 0, 0, 0, 1}, new byte[]{-1, -1, -1, -1, -1, -1, -1, -1}});
+            assertEquals(writeAndCaptureRow("bigint", "-9223372036854775808", "-1", "0", "1", "9223372036854775807"),
+                new Serializable[]{new byte[]{-0x80, 0, 0, 0, 0, 0, 0, 0}, new byte[]{-1, -1, -1, -1, -1, -1, -1, -1}, new byte[]{0, 0, 0, 0, 0, 0, 0, 0}, new byte[]{0, 0, 0, 0, 0, 0, 0, 1},  new byte[]{0x7f, -1, -1, -1, -1, -1, -1, -1}});
+        } finally {
+            client.disconnect();
+        }
+    }
+
+    @Test
     public void testDeserializationOfDateAndTimeAsLongMicrosecondsPrecision() throws Exception {
         final BinaryLogClient client = new BinaryLogClient(slave.hostname, slave.port,
             slave.username, slave.password);

--- a/src/test/onetimeserver
+++ b/src/test/onetimeserver
@@ -5,9 +5,9 @@ PLATFORM=${_PLATFORM/ /-}
 
 OS=`uname -s | tr '[:upper:]' '[:lower:]'`
 
-THIS_URL="https://gitee.com/zengzetang/onetimeserver/raw/master/onetimeserver"
-WRAPPER_URL="https://gitee.com/zengzetang/onetimeserver/raw/master/wrapper/wrapper.c"
-ONETIMESERVER_URL="http://localhost:8888/Desktop/onetimeserver-go.txt"
+THIS_URL="https://raw.githubusercontent.com/osheroff/onetimeserver/master/onetimeserver"
+WRAPPER_URL="https://raw.githubusercontent.com/osheroff/onetimeserver/master/wrapper/wrapper.c"
+ONETIMESERVER_URL="https://raw.githubusercontent.com/osheroff/onetimeserver-binaries/master/onetimeserver-go/$OS/onetimeserver-go"
 CACHE_DIR=$HOME/.onetimeserver/$PLATFORM
 
 function usage() {

--- a/src/test/onetimeserver
+++ b/src/test/onetimeserver
@@ -5,9 +5,9 @@ PLATFORM=${_PLATFORM/ /-}
 
 OS=`uname -s | tr '[:upper:]' '[:lower:]'`
 
-THIS_URL="https://raw.githubusercontent.com/osheroff/onetimeserver/master/onetimeserver"
-WRAPPER_URL="https://raw.githubusercontent.com/osheroff/onetimeserver/master/wrapper/wrapper.c"
-ONETIMESERVER_URL="https://raw.githubusercontent.com/osheroff/onetimeserver-binaries/master/onetimeserver-go/$OS/onetimeserver-go"
+THIS_URL="https://gitee.com/zengzetang/onetimeserver/raw/master/onetimeserver"
+WRAPPER_URL="https://gitee.com/zengzetang/onetimeserver/raw/master/wrapper/wrapper.c"
+ONETIMESERVER_URL="http://localhost:8888/Desktop/onetimeserver-go.txt"
 CACHE_DIR=$HOME/.onetimeserver/$PLATFORM
 
 function usage() {


### PR DESCRIPTION
I run `mvn checkstyle:check` but so many errors, so I am not sure whether the style is followed now. 
```
...
[ERROR] src/main/java/com/github/shyiko/mysql/binlog/network/SocketFactory.java:[26,5] (javadoc) MissingJavadocMethod: 缺少 Javadoc 。
[ERROR] src/main/java/com/github/shyiko/mysql/binlog/network/SSLMode.java:[19] (sizes) LineLength: 本行字符数 112个，最多：80个。
[ERROR] src/main/java/com/github/shyiko/mysql/binlog/network/SSLMode.java:[26] (sizes) LineLength: 本行字符数 91个，最多：80个。
[ERROR] src/main/java/com/github/shyiko/mysql/binlog/network/SSLMode.java:[36] (sizes) LineLength: 本行字符数 81个，最多：80个。
[ERROR] src/main/java/com/github/shyiko/mysql/binlog/network/SSLMode.java:[40] (sizes) LineLength: 本行字符数 117个，最多：80个。
[ERROR] src/main/java/com/github/shyiko/mysql/binlog/network/SSLMode.java:[41] (sizes) LineLength: 本行字符数 102个，最多：80个。
[ERROR] src/main/java/com/github/shyiko/mysql/binlog/network/SSLMode.java:[45] (sizes) LineLength: 本行字符数 118个，最多：80个。
...
```
I add a test, but fail to run it, feel free to fix it if my test or code fails if you can run the tests.
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running com.github.shyiko.mysql.binlog.BinaryLogClientIntegrationTest
Child exited without printing info!
Oct 25, 2020 5:28:32 AM com.github.shyiko.mysql.binlog.MysqlOnetimeServer boot
SEVERE: got exception while parsing null
java.lang.NullPointerException
	at com.fasterxml.jackson.core.JsonFactory.createParser(JsonFactory.java:889)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3024)
	at com.github.shyiko.mysql.binlog.MysqlOnetimeServer.boot(MysqlOnetimeServer.java:110)
	at com.github.shyiko.mysql.binlog.BinaryLogClientIntegrationTest.setUp(BinaryLogClientIntegrationTest.java:128)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:84)
	at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:564)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:213)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:138)
	at org.testng.internal.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:175)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:107)
	at org.testng.TestRunner.privateRun(TestRunner.java:767)
	at org.testng.TestRunner.run(TestRunner.java:617)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:334)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:329)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:291)

```