### PR TITLE
mariadb-support: MariaDB event types

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/EventType.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/EventType.java
@@ -25,90 +25,90 @@ public enum EventType {
     /**
      * Events of this event type should never occur. Not written to a binary log.
      */
-    UNKNOWN,
+    UNKNOWN(0),
     /**
      * A descriptor event that is written to the beginning of the each binary log file. (In MySQL 4.0 and 4.1,
      * this event is written only to the first binary log file that the server creates after startup.) This event is
      * used in MySQL 3.23 through 4.1 and superseded in MySQL 5.0 by {@link #FORMAT_DESCRIPTION}.
      */
-    START_V3,
+    START_V3(1),
     /**
      * Written when an updating statement is done.
      */
-    QUERY,
+    QUERY(2),
     /**
      * Written when mysqld stops.
      */
-    STOP,
+    STOP(3),
     /**
      * Written when mysqld switches to a new binary log file. This occurs when someone issues a FLUSH LOGS statement or
      * the current binary log file becomes larger than max_binlog_size.
      */
-    ROTATE,
+    ROTATE(4),
     /**
      * Written every time a statement uses an AUTO_INCREMENT column or the LAST_INSERT_ID() function; precedes other
      * events for the statement. This is written only before a {@link #QUERY} and is not used in case of RBR.
      */
-    INTVAR,
+    INTVAR(5),
     /**
      * Used for LOAD DATA INFILE statements in MySQL 3.23.
      */
-    LOAD,
+    LOAD(6),
     /**
      * Not used.
      */
-    SLAVE,
+    SLAVE(7),
     /**
      * Used for LOAD DATA INFILE statements in MySQL 4.0 and 4.1.
      */
-    CREATE_FILE,
+    CREATE_FILE(8),
     /**
      * Used for LOAD DATA INFILE statements as of MySQL 4.0.
      */
-    APPEND_BLOCK,
+    APPEND_BLOCK(9),
     /**
      * Used for LOAD DATA INFILE statements in 4.0 and 4.1.
      */
-    EXEC_LOAD,
+    EXEC_LOAD(10),
     /**
      * Used for LOAD DATA INFILE statements as of MySQL 4.0.
      */
-    DELETE_FILE,
+    DELETE_FILE(11),
     /**
      * Used for LOAD DATA INFILE statements in MySQL 4.0 and 4.1.
      */
-    NEW_LOAD,
+    NEW_LOAD(12),
     /**
      * Written every time a statement uses the RAND() function; precedes other events for the statement. Indicates the
      * seed values to use for generating a random number with RAND() in the next statement. This is written only
      * before a {@link #QUERY} and is not used in case of RBR.
      */
-    RAND,
+    RAND(13),
     /**
      * Written every time a statement uses a user variable; precedes other events for the statement. Indicates the
      * value to use for the user variable in the next statement. This is written only before a {@link #QUERY} and
      * is not used in case of RBR.
      */
-    USER_VAR,
+    USER_VAR(14),
     /**
      * A descriptor event that is written to the beginning of the each binary log file.
      * This event is used as of MySQL 5.0; it supersedes {@link #START_V3}.
      */
-    FORMAT_DESCRIPTION,
+    FORMAT_DESCRIPTION(15),
     /**
      * Generated for a commit of a transaction that modifies one or more tables of an XA-capable storage engine.
      * Normal transactions are implemented by sending a {@link #QUERY} containing a BEGIN statement and a {@link #QUERY}
      * containing a COMMIT statement (or a ROLLBACK statement if the transaction is rolled back).
      */
-    XID,
+    XID(16),
     /**
      * Used for LOAD DATA INFILE statements as of MySQL 5.0.
      */
-    BEGIN_LOAD_QUERY,
+    BEGIN_LOAD_QUERY(17),
     /**
      * Used for LOAD DATA INFILE statements as of MySQL 5.0.
      */
-    EXECUTE_LOAD_QUERY,
+    EXECUTE_LOAD_QUERY(18),
     /**
      * This event precedes each row operation event. It maps a table definition to a number, where the table definition
      * consists of database and table names and column definitions. The purpose of this event is to enable replication
@@ -117,82 +117,93 @@ public enum EventType {
      * of TABLE_MAP events: one per table used by events in the sequence.
      * Used in case of RBR.
      */
-    TABLE_MAP,
+    TABLE_MAP(19),
     /**
      * Describes inserted rows (within a single table).
      * Used in case of RBR (5.1.0 - 5.1.15).
      */
-    PRE_GA_WRITE_ROWS,
+    PRE_GA_WRITE_ROWS(20),
     /**
      * Describes updated rows (within a single table).
      * Used in case of RBR (5.1.0 - 5.1.15).
      */
-    PRE_GA_UPDATE_ROWS,
+    PRE_GA_UPDATE_ROWS(21),
     /**
      * Describes deleted rows (within a single table).
      * Used in case of RBR (5.1.0 - 5.1.15).
      */
-    PRE_GA_DELETE_ROWS,
+    PRE_GA_DELETE_ROWS(22),
     /**
      * Describes inserted rows (within a single table).
      * Used in case of RBR (5.1.16 - mysql-trunk).
      */
-    WRITE_ROWS,
+    WRITE_ROWS(23),
     /**
      * Describes updated rows (within a single table).
      * Used in case of RBR (5.1.16 - mysql-trunk).
      */
-    UPDATE_ROWS,
+    UPDATE_ROWS(24),
     /**
      * Describes deleted rows (within a single table).
      * Used in case of RBR (5.1.16 - mysql-trunk).
      */
-    DELETE_ROWS,
+    DELETE_ROWS(25),
     /**
      * Used to log an out of the ordinary event that occurred on the master. It notifies the slave that something
      * happened on the master that might cause data to be in an inconsistent state.
      */
-    INCIDENT,
+    INCIDENT(26),
     /**
      * Sent by a master to a slave to let the slave know that the master is still alive. Not written to a binary log.
      */
-    HEARTBEAT,
+    HEARTBEAT(27),
     /**
      * In some situations, it is necessary to send over ignorable data to the slave: data that a slave can handle in
      * case there is code for handling it, but which can be ignored if it is not recognized.
      */
-    IGNORABLE,
+    IGNORABLE(28),
     /**
      * Introduced to record the original query for rows events in RBR.
      */
-    ROWS_QUERY,
+    ROWS_QUERY(29),
     /**
      * Describes inserted rows (within a single table).
      * Used in case of RBR (5.1.18+).
      */
-    EXT_WRITE_ROWS,
+    EXT_WRITE_ROWS(30),
     /**
      * Describes updated rows (within a single table).
      * Used in case of RBR (5.1.18+).
      */
-    EXT_UPDATE_ROWS,
+    EXT_UPDATE_ROWS(31),
     /**
      * Describes deleted rows (within a single table).
      * Used in case of RBR (5.1.18+).
      */
-    EXT_DELETE_ROWS,
+    EXT_DELETE_ROWS(32),
     /**
      * Global Transaction Identifier.
      */
-    GTID,
-    ANONYMOUS_GTID,
-    PREVIOUS_GTIDS,
-    TRANSACTION_CONTEXT,
-    VIEW_CHANGE,
+    GTID(33),
+    ANONYMOUS_GTID(34),
+    PREVIOUS_GTIDS(35),
+    TRANSACTION_CONTEXT(36),
+    VIEW_CHANGE(37),
+
     /**
      * Prepared XA transaction terminal event similar to XID except that it is specific to XA transaction.
      */
-    XA_PREPARE;
+    XA_PREPARE(38),
+
+    /**
+     * MariaDB Events
+     */
+
+    ANNOTATE_ROWS(160),
+    BINLOG_CHECKPOINT(161),
+    MARIADB_GTID(162),
+    MARIADB_GTID_LIST(163),
+    START_ENCRYPTION(164);
 
     public static boolean isRowMutation(EventType eventType) {
         return EventType.isWrite(eventType) ||
@@ -216,6 +227,32 @@ public enum EventType {
         return eventType == PRE_GA_DELETE_ROWS ||
                eventType == DELETE_ROWS ||
                eventType == EXT_DELETE_ROWS;
+    }
+
+    private final int eventNumber;
+    private static EventType[] typesByEventNumber;
+
+    public  int getEventNumber() {
+        return eventNumber;
+    }
+
+    private static void setEvent(int eventNumber,  EventType t) {
+        if(typesByEventNumber == null) {
+            typesByEventNumber = new EventType[256];
+        }
+        if(typesByEventNumber[eventNumber] != null) {
+            throw new IllegalArgumentException("duplicate event number: " + eventNumber);
+        }
+        typesByEventNumber[eventNumber] = t;
+    }
+
+    private EventType(int eventNumber) {
+        this.eventNumber = eventNumber;
+        setEvent(eventNumber,this);
+    }
+
+    public static EventType byEventNumber(int eventNumber) {
+        return typesByEventNumber[eventNumber];
     }
 
 }

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventHeaderV4Deserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventHeaderV4Deserializer.java
@@ -40,11 +40,14 @@ public class EventHeaderV4Deserializer implements EventHeaderDeserializer<EventH
         return header;
     }
 
-    private static EventType getEventType(int ordinal) {
-        if (ordinal >= EVENT_TYPES.length) {
+    private static EventType getEventType(int eventNumber) {
+
+        EventType t = EventType.byEventNumber(eventNumber);
+        if(t == null) {
             return EventType.UNKNOWN;
+        } else {
+            return t;
         }
-        return EVENT_TYPES[ordinal];
     }
 
 }


### PR DESCRIPTION
* Change EventType to use eventNumber not ordinal().

* Add MariaDB event types.

    ANNOTATE_ROWS(160),
    BINLOG_CHECKPOINT(161)
    MARIADB_GTID(162)
    MARIADB_GTID_LIST(163)
    START_ENCRYPTION(164)

Question is that can be use this eventNumber approach, or go back to ordinal(), 
where we have to have fake-events in place of unused events before 160. ??

It will be other PR to add real MariaDB event types and their deserializers. 