### PR TITLE
Add Auth Plugin Name to for native password auth to fix Azure connections

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/network/protocol/command/AuthenticateSecurityPasswordCommand.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/network/protocol/command/AuthenticateSecurityPasswordCommand.java
@@ -77,6 +77,7 @@ public class AuthenticateSecurityPasswordCommand implements Command {
         if (schema != null) {
             buffer.writeZeroTerminatedString(schema);
         }
+        buffer.writeZeroTerminatedString("mysql_native_password");
         return buffer.toByteArray();
     }
 


### PR DESCRIPTION
PLUGIN_AUTH is listed as one of the capabilities and connections to Azure MySQL require the Auth Plugin Name to be specified when that capability is present. If it is not there, Azure MySQL instances respond with "The connection string may not be right. Please visit portal for references.".

See https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse and https://github.com/osheroff/mysql-binlog-connector-java/issues/26 for more details about the investigation.