### PR TITLE
Provide fast skip method implementation

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/json/JsonBinary.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/json/JsonBinary.java
@@ -403,7 +403,7 @@ public class JsonBinary {
             } else {
                 // Parse the value ...
                 this.reader.reset();
-                this.reader.skip(objectOffset + entry.index);
+                this.reader.fastSkip(objectOffset + entry.index);
                 parse(entry.type, formatter);
             }
         }
@@ -537,7 +537,7 @@ public class JsonBinary {
             } else {
                 // Parse the value ...
                 this.reader.reset();
-                this.reader.skip(arrayOffset + entry.index);
+                this.reader.fastSkip(arrayOffset + entry.index);
 
                 parse(entry.type, formatter);
             }

--- a/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
@@ -242,8 +242,25 @@ public class ByteArrayInputStream extends InputStream {
         inputStream.reset();
     }
 
+    /**
+     * This method implements fast-forward skipping in the stream.
+     * It can be used if and only if the underlying stream is fully available till its end.
+     * In other cases the regular {@link #skip(long)} method must be used.
+     *
+     * @param n - number of bytes to skip
+     * @return number of bytes skipped
+     * @throws IOException
+     */
     public synchronized long fastSkip(long n) throws IOException {
-        pos += (int) n;
-        return inputStream.skip(n);
-    }
+        long skipOf = n;
+        if (blockLength != -1) {
+            skipOf = Math.min(blockLength, skipOf);
+            blockLength -= skipOf;
+            if (blockLength == 0) {
+                blockLength = -1;
+            }
+        }
+        pos += (int) skipOf;
+        return inputStream.skip(skipOf);
+     }
 }

--- a/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
@@ -241,4 +241,9 @@ public class ByteArrayInputStream extends InputStream {
         pos = markPosition;
         inputStream.reset();
     }
+
+    public synchronized long fastSkip(long n) throws IOException {
+        pos += (int) n;
+        return inputStream.skip(n);
+    }
 }


### PR DESCRIPTION
When the JSON parser was skipping parts of the stream it used default skip implementation. The default one is base on reading the content of the stream to skip to the position which has O(n^2) comeplexity and becomes very slow for large JSON files.
By providing this method we just move the marker in the underlying stream without the need to go through expensive reading.