### PR TITLE
Set DefaultSSLSocketFactory to TLSv1.2 in line with JDK 11.0.11: 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.zendesk</groupId>
     <artifactId>mysql-binlog-connector-java</artifactId>
-    <version>0.25.1</version>
+    <version>0.26.0</version>
 
     <name>mysql-binlog-connector-java</name>
     <description>MySQL Binary Log connector</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.zendesk</groupId>
     <artifactId>mysql-binlog-connector-java</artifactId>
-    <version>0.26.0</version>
+    <version>0.25.1</version>
 
     <name>mysql-binlog-connector-java</name>
     <description>MySQL Binary Log connector</description>

--- a/src/main/java/com/github/shyiko/mysql/binlog/network/DefaultSSLSocketFactory.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/network/DefaultSSLSocketFactory.java
@@ -30,11 +30,11 @@ public class DefaultSSLSocketFactory implements SSLSocketFactory {
     private final String protocol;
 
     public DefaultSSLSocketFactory() {
-        this("TLSv1");
+        this("TLSv1.2");
     }
 
     /**
-     * @param protocol TLSv1, TLSv1.1 or TLSv1.2 (the last two require JDK 7+)
+     * @param protocol TLSv1, TLSv1.1 or TLSv1.2. Since JDK 11.0.11, TLSv1 and TLSv1.1 are no longer supported.
      */
     public DefaultSSLSocketFactory(String protocol) {
         this.protocol = protocol;


### PR DESCRIPTION
As of JDK 11.0.11, TLS1.0 and TLS1.1 have been disabled by default. This change sets the default SSLSocketFactory to use TLSv1.2 to be consistent with JDK 11.0.11.

Reference for JDK 11.0.11: https://www.oracle.com/java/technologies/javase/11-0-11-relnotes.html#JDK-8202343