### PR TITLE
avoid computing lag for events not having timestamp (HEARTBEAT)

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/jmx/BinaryLogClientStatistics.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/jmx/BinaryLogClientStatistics.java
@@ -18,6 +18,7 @@ package com.github.shyiko.mysql.binlog.jmx;
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventHeader;
+import com.github.shyiko.mysql.binlog.event.EventType;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -64,6 +65,9 @@ public class BinaryLogClientStatistics implements BinaryLogClientStatisticsMXBea
         EventHeader eventHeader = lastEventHeader.get();
         if (timestamp == 0 || eventHeader == null) {
             return -1;
+        }
+        if (eventHeader.getEventType() == EventType.HEARTBEAT && eventHeader.getTimestamp() == 0) {
+            return 0;
         }
         return (timestamp - eventHeader.getTimestamp()) / 1000;
     }


### PR DESCRIPTION
I've found the existence of HEARTBEAT events. These events do not contain timestamp in their header, therefore the current way of computing `secondsBehindMaster` does not work:
``` java
(timestampOfLastEvent  - eventHeader.getTimestamp()) / 1000
```
This is the HEARTBEAT event type definition:
> An artificial event generated by the master. It isn't written to the relay logs.

>It is added by the master after the replication connection was idle for x-seconds to update the slave's Seconds_Behind_Master timestamp in the SHOW SLAVE STATUS output.

>It has no payload nor post-header.

So I think it makes sense in the current implementation of `secondsBehindMaster` to compute it as `0` seconds behind master.