### PR TITLE
correct mariadb_slave_capability value

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -788,10 +788,15 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
 
     protected void requestBinaryLogStreamMaria(long serverId) throws IOException {
         Command dumpBinaryLogCommand;
+
+        /*
+            https://jira.mariadb.org/browse/MDEV-225
+         */
+        channel.write(new QueryCommand("SET @mariadb_slave_capability=1"));
+        checkError(channel.read());
+
         synchronized (gtidSetAccessLock) {
             if (this.gtidEnabled) {
-                channel.write(new QueryCommand("SET @mariadb_slave_capability=4"));
-                checkError(channel.read());
                 logger.info(gtidSet.toString());
                 channel.write(new QueryCommand("SET @slave_connect_state = '" + gtidSet.toString() + "'"));
                 checkError(channel.read());

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientIntegrationTest.java
@@ -806,7 +806,7 @@ public class BinaryLogClientIntegrationTest extends AbstractIntegrationTest {
                         statement.execute("flush logs");
                     }
                 });
-                eventListener.waitFor(EventType.QUERY, 1, DEFAULT_TIMEOUT);
+                eventListener.waitForAtLeast(EventType.QUERY, 1, DEFAULT_TIMEOUT);
                 eventListener.waitFor(EventType.ROTATE, 3, DEFAULT_TIMEOUT); /* 2 with timestamp 0 */
                 eventListener.waitFor(ByteArrayEventData.class, 5, DEFAULT_TIMEOUT);
             } finally {


### PR DESCRIPTION
I think it's fair to say we understand ANNOTATE_ROWS_EVENT, but none of
the other stuff represented by this variable is true.