### PR TITLE
Fix isContainedWithin for MariaDb to correctly return true when ranges are equivalent

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/MariadbGtidSet.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/MariadbGtidSet.java
@@ -145,7 +145,7 @@ public class MariadbGtidSet extends GtidSet {
 
                 MariaGtid thisGtid = thisDomainMap.get(serverID);
                 MariaGtid otherGtid = otherDomainMap.get(serverID);
-                if ( thisGtid.sequence >= otherGtid.sequence )
+                if ( thisGtid.sequence > otherGtid.sequence )
                     return false;
             }
         }


### PR DESCRIPTION
Currently, isContainedWithin will return false when the gtid sets are equal, even though equivalence implies that one contains the other and vice versa, per the contract of the method it's overriding:

https://github.com/osheroff/mysql-binlog-connector-java/blob/master/src/main/java/com/github/shyiko/mysql/binlog/GtidSet.java#L122

Right now this breaks logical equivalence for anyone that uses this to determine whether two sets are logically equal

Link https://github.com/osheroff/mysql-binlog-connector-java/issues/91