### PR TITLE
Exposed initial capacity of StringBuilder through the JsonStringFormatter constructor

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/json/JsonStringFormatter.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/json/JsonStringFormatter.java
@@ -68,7 +68,19 @@ public class JsonStringFormatter implements JsonFormatter {
 
     private static final char[] HEX_CODES = "0123456789ABCDEF".toCharArray();
 
-    private final StringBuilder sb = new StringBuilder();
+    private final StringBuilder sb;
+
+    public JsonStringFormatter() {
+        this.sb = new StringBuilder();
+    }
+
+    /**
+     * Constructs a JsonFormatter with the given initial capacity.
+     * @param capacity the initial capacity. Should be a positive number.
+     */
+    public JsonStringFormatter(int capacity) {
+        this.sb = new StringBuilder(capacity);
+    }
 
     @Override
     public String toString() {
@@ -115,12 +127,12 @@ public class JsonStringFormatter implements JsonFormatter {
 
     @Override
     public void value(int value) {
-        sb.append(Integer.toString(value));
+        sb.append(value);
     }
 
     @Override
     public void value(long value) {
-        sb.append(Long.toString(value));
+        sb.append(value);
     }
 
     @Override

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/json/JsonStringFormatterTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/json/JsonStringFormatterTest.java
@@ -1,0 +1,45 @@
+package com.github.shyiko.mysql.binlog.event.deserialization.json;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class JsonStringFormatterTest {
+
+    @Test
+    public void testFormatLong() {
+        assertLong(1234567890L, "1234567890");
+        assertLong(-1234567890L, "-1234567890");
+        assertLong(0L, "0");
+        assertLong(Long.MAX_VALUE, Long.toString(Long.MAX_VALUE));
+        assertLong(Long.MIN_VALUE, Long.toString(Long.MIN_VALUE));
+    }
+
+    @Test
+    public void testFormatInt() {
+        assertInt(1234567890, "1234567890");
+        assertInt(-1234567890, "-1234567890");
+        assertInt(0, "0");
+        assertInt(Integer.MAX_VALUE, Integer.toString(Integer.MAX_VALUE));
+        assertInt(Integer.MIN_VALUE, Integer.toString(Integer.MIN_VALUE));
+    }
+
+    @Test
+    public void testNewFormatterWithInitialCapacity() {
+        JsonStringFormatter formatter = new JsonStringFormatter(32);
+        formatter.value("test");
+        assertEquals(formatter.getString(), "\"test\"");
+    }
+
+    private static void assertLong(long value, String expected) {
+        JsonStringFormatter json = new JsonStringFormatter();
+        json.value(value);
+        assertEquals(json.getString(), expected);
+    }
+
+    private static void assertInt(int value, String expected) {
+        JsonStringFormatter json = new JsonStringFormatter();
+        json.value(value);
+        assertEquals(json.getString(), expected);
+    }
+}


### PR DESCRIPTION
Exposed initial capacity of StringBuilder through the JsonStringFormatter constructor to be able to avoid allocating a lot of new internal buffers in StringBuilder for large Json values. Also removed unnecessary calls to Integer.toString and Long.toString.