### PR TITLE
Avoid string formatting during gtid event data deserialization and st…

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -144,7 +144,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     private boolean gtidSetFallbackToPurged;
     private boolean gtidEnabled = false;
     private boolean useBinlogFilenamePositionInGtidMode;
-    protected String gtid;
+    protected Object gtid;
     private boolean tx;
 
     private EventDeserializer eventDeserializer = new EventDeserializer();
@@ -1131,7 +1131,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
         switch(eventHeader.getEventType()) {
             case GTID:
                 GtidEventData gtidEventData = (GtidEventData) EventDataWrapper.internal(event.getData());
-                gtid = gtidEventData.getGtid();
+                gtid = gtidEventData.getMySqlGtid();
                 break;
             case XID:
                 commitGtid();
@@ -1183,7 +1183,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     private void commitGtid() {
         if (gtid != null) {
             synchronized (gtidSetAccessLock) {
-                gtidSet.add(gtid);
+                gtidSet.addGtid(gtid);
             }
         }
     }

--- a/src/main/java/com/github/shyiko/mysql/binlog/MariadbGtidSet.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/MariadbGtidSet.java
@@ -1,5 +1,7 @@
 package com.github.shyiko.mysql.binlog;
 
+import com.github.shyiko.mysql.binlog.event.MySqlGtid;
+
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -111,6 +113,16 @@ public class MariadbGtidSet extends GtidSet {
         MariaGtid mariaGtid = MariaGtid.parse(gtid);
         add(mariaGtid);
         return true;
+    }
+
+    public void addGtid(Object gtid) {
+        if (gtid instanceof MariaGtid) {
+            add((MariaGtid) gtid);
+        } else if (gtid instanceof String) {
+            add((String) gtid);
+        } else {
+            throw new IllegalArgumentException(gtid + " not supported");
+        }
     }
 
     public void add(MariaGtid gtid) {

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/GtidEventData.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/GtidEventData.java
@@ -22,21 +22,37 @@ public class GtidEventData implements EventData {
 
     public static final byte COMMIT_FLAG = 1;
 
-    private String gtid;
+    private MySqlGtid gtid;
     private byte flags;
 
-    public String getGtid() {
-        return gtid;
+    @Deprecated
+    public GtidEventData() {
     }
 
-    public void setGtid(String gtid) {
+    public GtidEventData(MySqlGtid gtid, byte flags) {
         this.gtid = gtid;
+        this.flags = flags;
+    }
+
+    @Deprecated
+    public String getGtid() {
+        return gtid.toString();
+    }
+
+    @Deprecated
+    public void setGtid(String gtid) {
+        this.gtid = MySqlGtid.fromString(gtid);
+    }
+
+    public MySqlGtid getMySqlGtid() {
+        return gtid;
     }
 
     public byte getFlags() {
         return flags;
     }
 
+    @Deprecated
     public void setFlags(byte flags) {
         this.flags = flags;
     }

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/MySqlGtid.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/MySqlGtid.java
@@ -1,0 +1,33 @@
+package com.github.shyiko.mysql.binlog.event;
+
+import java.util.UUID;
+
+public class MySqlGtid {
+    private final UUID serverId;
+    private final long transactionId;
+
+    public MySqlGtid(UUID serverId, long transactionId) {
+        this.serverId = serverId;
+        this.transactionId = transactionId;
+    }
+
+    public static MySqlGtid fromString(String gtid) {
+        String[] split = gtid.split(":");
+        String sourceId = split[0];
+        long transactionId = Long.parseLong(split[1]);
+        return new MySqlGtid(UUID.fromString(sourceId), transactionId);
+    }
+
+    @Override
+    public String toString() {
+        return serverId.toString()+":"+transactionId;
+    }
+
+    public UUID getServerId() {
+        return serverId;
+    }
+
+    public long getTransactionId() {
+        return transactionId;
+    }
+}

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/GtidEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/GtidEventDataDeserializer.java
@@ -29,16 +29,24 @@ public class GtidEventDataDeserializer implements EventDataDeserializer<GtidEven
     @Override
     public GtidEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
         byte flags = (byte) inputStream.readInteger(1);
-        long sourceIdLeastSignificantBits = inputStream.readLong(8);
-        long sourceIdMostSignificantBits = inputStream.readLong(8);
+        long sourceIdMostSignificantBits = readLongBigEndian(inputStream);
+        long sourceIdLeastSignificantBits = readLongBigEndian(inputStream);
         long transactionId = inputStream.readLong(8);
 
         return new GtidEventData(
             new MySqlGtid(
-                new UUID(sourceIdLeastSignificantBits, sourceIdMostSignificantBits),
+                new UUID(sourceIdMostSignificantBits, sourceIdLeastSignificantBits),
                 transactionId
             ),
             flags
         );
+    }
+
+    private static long readLongBigEndian(ByteArrayInputStream input) throws IOException {
+        long result = 0;
+        for (int i = 0; i < 8; ++i) {
+            result = ((result << 8) | (input.read() & 0xff));
+        }
+        return result;
     }
 }

--- a/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/GtidSetTest.java
@@ -17,6 +17,7 @@ package com.github.shyiko.mysql.binlog;
 
 import com.github.shyiko.mysql.binlog.GtidSet.Interval;
 import com.github.shyiko.mysql.binlog.GtidSet.UUIDSet;
+import com.github.shyiko.mysql.binlog.event.MySqlGtid;
 import org.testng.annotations.Test;
 
 import java.util.LinkedList;
@@ -164,5 +165,23 @@ public class GtidSetTest {
         assertEquals(gtidSet, gtidSet2);
     }
 
+    @Test
+    public void testAddStringGtid() {
+        GtidSet gtidSet = new GtidSet("00000000-0000-0000-0000-000000000000:1");
+        gtidSet.addGtid("00000000-0000-0000-0000-000000000000:2");
+        assertEquals("00000000-0000-0000-0000-000000000000:1-2", gtidSet.toString());
+    }
 
+    @Test
+    public void testAddMySqlGtid() {
+        GtidSet gtidSet = new GtidSet("00000000-0000-0000-0000-000000000000:1");
+        gtidSet.addGtid(MySqlGtid.fromString("00000000-0000-0000-0000-000000000000:2"));
+        assertEquals("00000000-0000-0000-0000-000000000000:1-2", gtidSet.toString());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testAddAnotherObjectAsGtidFails() {
+        GtidSet gtidSet = new GtidSet("");
+        gtidSet.addGtid(MariadbGtidSet.MariaGtid.parse("1-2-3"));
+    }
 }

--- a/src/test/java/com/github/shyiko/mysql/binlog/MariadbGtidSetTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/MariadbGtidSetTest.java
@@ -1,5 +1,7 @@
 package com.github.shyiko.mysql.binlog;
 
+import com.github.shyiko.mysql.binlog.MariadbGtidSet.MariaGtid;
+import com.github.shyiko.mysql.binlog.event.MySqlGtid;
 import org.testng.annotations.Test;
 
 import static org.junit.Assert.assertFalse;
@@ -43,4 +45,26 @@ public class MariadbGtidSetTest {
         assertTrue(MariadbGtidSet.isMariaGtidSet("0-0-3323, 4-33-12342134, 444-33-13412341233"));
         assertFalse(MariadbGtidSet.isMariaGtidSet("07212070-4330-3bc8-8a3a-01e34be47bc3:1-141692942,a0c4a949-fae8-30f3-a4d2-fee56a1a9307:1-1427643460,a16ef643-1d4a-3fd9-a86e-1adeb836eb2d:1-1411988930,b0d822f4-5a84-30d3-a929-61f64740d7ac:1-59364"));
     }
+
+    @Test
+    public void testAddStringGtid() {
+        MariadbGtidSet gtidSet = new MariadbGtidSet();
+        gtidSet.addGtid("1-2-3");
+        assertEquals("1-2-3", gtidSet.toString());
+    }
+
+    @Test
+    public void testAddMariadbGtid() {
+        MariadbGtidSet gtidSet = new MariadbGtidSet();
+        gtidSet.addGtid(MariaGtid.parse("1-2-3"));
+        assertEquals("1-2-3", gtidSet.toString());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testAddAnotherObjectAsGtidFails() {
+        MariadbGtidSet gtidSet = new MariadbGtidSet();
+        gtidSet.addGtid(MySqlGtid.fromString("00000000-0000-0000-0000-000000000000:2"));
+    }
+
+
 }

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/MysqlGtidEventDataDeserializerTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/MysqlGtidEventDataDeserializerTest.java
@@ -1,0 +1,28 @@
+package com.github.shyiko.mysql.binlog.event.deserialization;
+
+import com.github.shyiko.mysql.binlog.event.GtidEventData;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.*;
+
+public class MysqlGtidEventDataDeserializerTest {
+
+    private GtidEventDataDeserializer deserializer = new GtidEventDataDeserializer();
+
+    @Test
+    public void testDeserialize() throws IOException {
+        GtidEventData data = deserializer.deserialize(new ByteArrayInputStream(
+            new byte[]{
+                0x03, //flags
+                (byte) 0xe6, 0x11, 0x16, 0x2c, 0x50, 0x78, (byte) 0xbc, 0x24, // sourceId leastSignificantBits little endian
+                0x02, 0x00, 0x11, (byte) 0xac, 0x42, 0x02, 0x73, (byte) 0xa0, //sourceId mostSignificantBits little endian
+                (byte) 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 // sequence little endian
+            }
+        ));
+        assertEquals(data.getFlags(), 0x03);
+        assertEquals(data.getMySqlGtid().toString(), "24bc7850-2c16-11e6-a073-0242ac110002:11");
+    }
+}

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/MysqlGtidEventDataDeserializerTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/MysqlGtidEventDataDeserializerTest.java
@@ -17,8 +17,8 @@ public class MysqlGtidEventDataDeserializerTest {
         GtidEventData data = deserializer.deserialize(new ByteArrayInputStream(
             new byte[]{
                 0x03, //flags
-                (byte) 0xe6, 0x11, 0x16, 0x2c, 0x50, 0x78, (byte) 0xbc, 0x24, // sourceId leastSignificantBits little endian
-                0x02, 0x00, 0x11, (byte) 0xac, 0x42, 0x02, 0x73, (byte) 0xa0, //sourceId mostSignificantBits little endian
+                0x24, (byte) 0xbc, 0x78, 0x50, 0x2c, 0x16, 0x11, (byte) 0xe6, // sourceId mostSignificantBits big endian
+                (byte) 0xa0, 0x73, 0x02, 0x42, (byte) 0xac, 0x11, 0x00, 0x02, // sourceId leastSignificantBits big endian
                 (byte) 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 // sequence little endian
             }
         ));


### PR DESCRIPTION
…ring parsing when adding the gtid to a GtidSet

This is a PR for item 1) in https://github.com/osheroff/mysql-binlog-connector-java/issues/98 

Afaik I did not break any interfaces, except I changed the `protected` gtid field in `BinaryLogClient` from `String` to `Object`

I didn't change the MariadbGtid handling until I know more about  https://github.com/osheroff/mysql-binlog-connector-java/issues/100