### PR TITLE
use internal index for EventType.byEventNumber instead of always crea…

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/EventType.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/EventType.java
@@ -15,6 +15,8 @@
  */
 package com.github.shyiko.mysql.binlog.event;
 
+import java.util.stream.Stream;
+
 /**
  * @author <a href="mailto:stanley.shyiko@gmail.com">Stanley Shyiko</a>
  * @see <a href="https://dev.mysql.com/doc/internals/en/event-meanings.html">Event Meanings</a> for the original
@@ -216,10 +218,21 @@ public enum EventType {
     MARIADB_GTID(162),
     MARIADB_GTID_LIST(163);
 
+    private static final EventType[] TYPE_BY_EVENT_NUMBER = buildEventTypeIndex();
     private final int eventNumber;
 
     EventType(int eventNumber) {
         this.eventNumber = eventNumber;
+    }
+
+    private static EventType[] buildEventTypeIndex() {
+        EventType[] types = EventType.values();
+        int maxEventNumber = Stream.of(types).mapToInt(t -> t.eventNumber).max().orElse(-1);
+        EventType[] index = new EventType[maxEventNumber+1];
+        for (EventType type : types) {
+            index[type.eventNumber] = type;
+        }
+        return index;
     }
 
     public static boolean isRowMutation(EventType eventType) {
@@ -247,11 +260,6 @@ public enum EventType {
     }
 
     public static EventType byEventNumber(int num) {
-        for (EventType type : EventType.values()) {
-            if (type.eventNumber == num) {
-                return type;
-            }
-        }
-        return null;
+        return num >= 0 && num < TYPE_BY_EVENT_NUMBER.length ? TYPE_BY_EVENT_NUMBER[num] : null;
     }
 }

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/EventTypeTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/EventTypeTest.java
@@ -21,8 +21,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 /**
  * @author <a href="mailto:stanley.shyiko@gmail.com">Stanley Shyiko</a>
@@ -69,5 +68,16 @@ public class EventTypeTest {
         for (EventType eventType : eventTypes) {
             assertFalse(EventType.isDelete(eventType));
         }
+    }
+
+    @Test
+    public void testByEventNumber() {
+        assertEquals(EventType.byEventNumber(0), EventType.UNKNOWN);
+        assertNull(EventType.byEventNumber(-1));
+        assertNull(EventType.byEventNumber(41));
+        assertNull(EventType.byEventNumber(159));
+        assertNull(EventType.byEventNumber(164));
+        assertEquals(EventType.byEventNumber(1), EventType.START_V3);
+        assertEquals(EventType.byEventNumber(163), EventType.MARIADB_GTID_LIST);
     }
 }


### PR DESCRIPTION
…ting an array and iterating

This is a PR that avoids the EventType array allocation that I saw while creating the allocation profiles in https://github.com/osheroff/mysql-binlog-connector-java/issues/98