### PR TITLE
Fix circleci build, in the integration test suite multiple events could be in the binary log

### DIFF
--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientGTIDIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientGTIDIntegrationTest.java
@@ -149,7 +149,6 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
                 public void onEvent(Event event) {
                     if (event.getHeader().getEventType() == EventType.GTID) {
                         actualServerId[0] = ((GtidEventData) event.getData()).getMySqlGtid().getServerId().toString();
-                        System.out.println("actualServerId = " + actualServerId[0]);
                     }
                 }
             });

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientGTIDIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientGTIDIntegrationTest.java
@@ -64,14 +64,7 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
     public void testGTIDAdvances() throws Exception {
         master.execute("CREATE TABLE if not exists foo (i int)");
 
-        final String[] initialGTIDSet = new String[1];
-        master.query("show master status", new Callback<ResultSet>() {
-            @Override
-            public void execute(ResultSet rs) throws SQLException {
-                rs.next();
-                initialGTIDSet[0] = rs.getString("Executed_Gtid_Set");
-            }
-        });
+        String initialGTIDSet = getExecutedGtidSet(master);
 
         EventDeserializer eventDeserializer = new EventDeserializer();
         try {
@@ -79,7 +72,7 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
             final BinaryLogClient clientWithKeepAlive = new BinaryLogClient(slave.hostname(), slave.port(),
                 slave.username(), slave.password());
 
-            clientWithKeepAlive.setGtidSet(initialGTIDSet[0]);
+            clientWithKeepAlive.setGtidSet(initialGTIDSet);
             clientWithKeepAlive.registerEventListener(eventListener);
             clientWithKeepAlive.setEventDeserializer(eventDeserializer);
             try {
@@ -130,6 +123,8 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
     public void testGtidServerId() throws Exception {
         master.execute("CREATE TABLE if not exists foo (i int)");
 
+        String initialGTIDSet = getExecutedGtidSet(master);
+
         final String[] expectedServerId = new String[1];
         master.query("select @@server_uuid", new Callback<ResultSet>() {
             @Override
@@ -144,21 +139,21 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
         EventDeserializer eventDeserializer = new EventDeserializer();
         try {
             client.disconnect();
-            final BinaryLogClient clientWithKeepAlive = new BinaryLogClient(slave.hostname(), slave.port(),
-                slave.username(), slave.password());
+            final BinaryLogClient clientWithKeepAlive = new BinaryLogClient(master.hostname(), master.port(),
+                master.username(), master.password());
 
-            clientWithKeepAlive.setGtidSet("");
-            clientWithKeepAlive.registerEventListener(eventListener);
-
+            clientWithKeepAlive.setGtidSet(initialGTIDSet);
 
             clientWithKeepAlive.registerEventListener(new BinaryLogClient.EventListener() {
                 @Override
                 public void onEvent(Event event) {
                     if (event.getHeader().getEventType() == EventType.GTID) {
                         actualServerId[0] = ((GtidEventData) event.getData()).getMySqlGtid().getServerId().toString();
+                        System.out.println("actualServerId = " + actualServerId[0]);
                     }
                 }
             });
+            clientWithKeepAlive.registerEventListener(eventListener);
             clientWithKeepAlive.setEventDeserializer(eventDeserializer);
             try {
                 eventListener.reset();
@@ -171,7 +166,7 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
                     }
                 });
 
-                eventListener.waitFor(XidEventData.class, 1, TimeUnit.SECONDS.toMillis(4));
+                eventListener.waitForAtLeast(EventType.GTID, 1, TimeUnit.SECONDS.toMillis(4));
                 assertEquals(actualServerId[0], expectedServerId[0]);
 
 
@@ -181,6 +176,18 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
         } finally {
             client.connect(DEFAULT_TIMEOUT);
         }
+    }
+
+    private String getExecutedGtidSet(MySQLConnection master) throws SQLException {
+        final String[] initialGTIDSet = new String[1];
+        master.query("show master status", new Callback<ResultSet>() {
+            @Override
+            public void execute(ResultSet rs) throws SQLException {
+                rs.next();
+                initialGTIDSet[0] = rs.getString("Executed_Gtid_Set");
+            }
+        });
+        return initialGTIDSet[0];
     }
 
 }


### PR DESCRIPTION
Hi @osheroff, I noticed the build broke on circleci because of my new integration test, maybe the execution order was different, the problem was it got more than one XID event (because of other transactions I suppose).

I narrowed the scope of my integration test:
We're only interested in one GTID event to check the for the serverId. Connect to master because we don't want a replica serverId in the first gtid.

