### PR TITLE
fix bug signedness order change to All Column Order

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventDataDeserializer.java
@@ -20,6 +20,8 @@ import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
 import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author <a href="mailto:stanley.shyiko@gmail.com">Stanley Shyiko</a>
@@ -47,13 +49,35 @@ public class TableMapEventDataDeserializer implements EventDataDeserializer<Tabl
             metadata = metadataDeserializer.deserialize(
                 new ByteArrayInputStream(inputStream.read(metadataLength)),
                 eventData.getColumnTypes().length,
-                numericColumnCount(eventData.getColumnTypes())
+                numericColumnCount(eventData.getColumnTypes()),
+                numericColumnIndex(eventData.getColumnTypes())
             );
         }
         eventData.setEventMetadata(metadata);
         return eventData;
     }
 
+    private List<Integer> numericColumnIndex(byte[] types){
+        ArrayList<Integer> numericColumnIndexList = new ArrayList<>();
+        for (int i = 0; i < types.length; i++) {
+            switch (ColumnType.byCode(types[i] & 0xff)) {
+                case TINY:
+                case SHORT:
+                case INT24:
+                case LONG:
+                case LONGLONG:
+                case NEWDECIMAL:
+                case FLOAT:
+                case DOUBLE:
+                case YEAR:
+                    numericColumnIndexList.add(i);
+                    break;
+                default:
+                    break;
+            }
+        }
+        return numericColumnIndexList;
+    }
     private int numericColumnCount(byte[] types) {
         int count = 0;
         for (int i = 0; i < types.length; i++) {

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventDataDeserializer.java
@@ -57,7 +57,7 @@ public class TableMapEventDataDeserializer implements EventDataDeserializer<Tabl
         return eventData;
     }
 
-    private List<Integer> numericColumnIndex(byte[] types){
+    private List<Integer> numericColumnIndex(byte[] types) {
         ArrayList<Integer> numericColumnIndexList = new ArrayList<>();
         for (int i = 0; i < types.length; i++) {
             switch (ColumnType.byCode(types[i] & 0xff)) {
@@ -78,6 +78,7 @@ public class TableMapEventDataDeserializer implements EventDataDeserializer<Tabl
         }
         return numericColumnIndexList;
     }
+
     private int numericColumnCount(byte[] types) {
         int count = 0;
         for (int i = 0; i < types.length; i++) {
@@ -103,7 +104,7 @@ public class TableMapEventDataDeserializer implements EventDataDeserializer<Tabl
     private int[] readMetadata(ByteArrayInputStream inputStream, byte[] columnTypes) throws IOException {
         int[] metadata = new int[columnTypes.length];
         for (int i = 0; i < columnTypes.length; i++) {
-            switch(ColumnType.byCode(columnTypes[i] & 0xFF)) {
+            switch (ColumnType.byCode(columnTypes[i] & 0xFF)) {
                 case FLOAT:
                 case DOUBLE:
                 case BLOB:

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventDataDeserializer.java
@@ -58,7 +58,7 @@ public class TableMapEventDataDeserializer implements EventDataDeserializer<Tabl
     }
 
     private List<Integer> numericColumnIndex(byte[] types) {
-        ArrayList<Integer> numericColumnIndexList = new ArrayList<>();
+        List<Integer> numericColumnIndexList = new ArrayList<>();
         for (int i = 0; i < types.length; i++) {
             switch (ColumnType.byCode(types[i] & 0xff)) {
                 case TINY:

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
@@ -69,7 +69,7 @@ public class TableMapEventMetadataDeserializer {
             switch (fieldType) {
                 case SIGNEDNESS:
                     result.setSignedness(
-                        convertColumnOrder(readBooleanList(inputStream, nNumericColumns), nColumns,
+                        convertAllColumnOrder(readBooleanList(inputStream, nNumericColumns), nColumns,
                                            numericColumIdxList));
                     break;
                 case DEFAULT_CHARSET:
@@ -113,21 +113,19 @@ public class TableMapEventMetadataDeserializer {
         return result;
     }
 
-    private static BitSet convertColumnOrder(BitSet numericOrderBitSet, int nColumns,
+    private static BitSet convertAllColumnOrder(BitSet numericOrderBitSet, int nColumns,
                                              List<Integer> numericColumIdxList) {
         // Case SIGNEDNESS The order of indices in the Inputstream corresponds to the order of numeric columns
         // So we need to change the index to all columns index (include non numeric type columns)
-
         BitSet columnOrderBitSet = new BitSet();
         int position = 0;
         for (int columnIndex = 0; columnIndex < nColumns; columnIndex++) {
-            if (numericColumIdxList.contains(columnIndex)) {
-                if (numericOrderBitSet.get(position++)) {
-                    columnOrderBitSet.set(columnIndex);
-                }
-
+            if (!numericColumIdxList.contains(columnIndex)) {
+                continue;
             }
-
+            if (numericOrderBitSet.get(position++)) {
+                columnOrderBitSet.set(columnIndex);
+            }
         }
         return columnOrderBitSet;
     }

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
@@ -113,8 +113,8 @@ public class TableMapEventMetadataDeserializer {
     }
 
     private static BitSet convertColumnOrder(BitSet numericOrderBitSet, List<Integer> numericColumIdxList) {
-        // case SIGNEDNESS The order of the index in the packet is only the index between the numeric_columns.
-        // So we need to map the index to the index in the all columns.
+        // Case SIGNEDNESS The order of indices in the Inputstream corresponds to the order of numeric columns
+        // So we need to map the index to all columns index (include non numeric type columns)
         Map<Integer, Integer> mappingColumnOrderMap = new HashMap<>();
 
         for (int numericColumnOrder = 0; numericColumnOrder < numericColumIdxList.size();

--- a/src/test/java/com/github/shyiko/mysql/binlog/OptionalMetaDataIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/OptionalMetaDataIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.github.shyiko.mysql.binlog;
+
+import static org.testng.Assert.assertEquals;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.BitSet;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClientIntegrationTest.Callback;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
+
+public class OptionalMetaDataIntegrationTest extends AbstractIntegrationTest {
+    protected static final long DEFAULT_TIMEOUT = TimeUnit.SECONDS.toMillis(3);
+
+    private final Logger logger = Logger.getLogger(getClass().getSimpleName());
+
+    {
+        logger.setLevel(Level.FINEST);
+    }
+
+    public void checkMysqlVersion() throws Exception {
+        if (!mysqlVersion.atLeast(8, 0)) {
+            throw new SkipException("For Optional Meta Data Test MYSQL VERSION SHOULD BE MORE THAN 8.0");
+        }
+    }
+
+    @BeforeMethod
+    public void beforeEachTest() throws Exception {
+        checkMysqlVersion();
+        master.execute(new Callback<Statement>() {
+            @Override
+            public void execute(Statement statement) throws SQLException {
+                statement.execute("drop table if exists optionalMetaDataIntegrationTest");
+                statement.execute(
+                    "create table optionalMetaDataIntegrationTest (col1 int unsigned , col2 int, col3 varchar(30), col4 int unsigned)");
+            }
+        });
+        eventListener.waitForAtLeast(EventType.QUERY, 2, DEFAULT_TIMEOUT);
+        eventListener.reset();
+    }
+
+    @Test
+    public void testSignedness() throws Exception {
+        CapturingEventListener capturingEventListener = new CapturingEventListener();
+        client.registerEventListener(capturingEventListener);
+        // ensure "capturingEventListener -> eventListener" order
+        client.unregisterEventListener(eventListener);
+        client.registerEventListener(eventListener);
+        try {
+            master.execute(new Callback<Statement>() {
+                @Override
+                public void execute(Statement statement) throws SQLException {
+                    statement.execute("insert into optionalMetaDataIntegrationTest values (1,2,3,4)");
+                }
+            });
+            eventListener.waitFor(TableMapEventData.class, 1, DEFAULT_TIMEOUT);
+            TableMapEventMetadata eventMetadata = capturingEventListener.getEvents(TableMapEventData.class).get(
+                0).getEventMetadata();
+            BitSet expectBitSet = new BitSet();
+            expectBitSet.set(0);
+            expectBitSet.set(3);
+            assertEquals(eventMetadata.getSignedness(), expectBitSet);
+
+        } finally {
+            client.unregisterEventListener(capturingEventListener);
+        }
+    }
+
+}

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
@@ -5,6 +5,7 @@ import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -29,7 +30,7 @@ public class TableMapEventMetadataDeserializerTest {
         byte[] metadataIncludingUnknownFieldType = {1, 2, 0, -128, 2, 9, 83, 6, 63, 7, 63, 8, 63, 9, 63};
         TableMapEventMetadataDeserializer deserializer = new TableMapEventMetadataDeserializer();
         TableMapEventMetadata tableMapEventMetadata =
-            deserializer.deserialize(new ByteArrayInputStream(metadataIncludingUnknownFieldType), 23, 8);
+            deserializer.deserialize(new ByteArrayInputStream(metadataIncludingUnknownFieldType), 23, 8, Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7)); // suppose there numeric Columns Idx are 0, 1, 2, 3, 4, 5, 6, 7
 
         Map<Integer, Integer> expectedCharsetCollations = new LinkedHashMap<>();
         expectedCharsetCollations.put(6, 63);

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
@@ -2,6 +2,7 @@ package com.github.shyiko.mysql.binlog.event.deserialization;
 
 import com.github.shyiko.mysql.binlog.event.TableMapEventMetadata;
 import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -29,14 +30,16 @@ public class TableMapEventMetadataDeserializerTest {
      */
     @Test
     public void deserialize() throws IOException {
-        byte[] metadataIncludingUnknownFieldType = {1, 2, -1, 2, 9, 83, 6, 63, 7, 63, 8, 63, 9, 63};
+        byte[] metadataIncludingUnknownFieldType = { 1, 1, 29, 2, 9, 83, 6, 63, 7, 63, 8, 63, 9, 63 };
         TableMapEventMetadataDeserializer deserializer = new TableMapEventMetadataDeserializer();
         // suppose there Columns idx likes
-        // col 0, 2, 4, 6, 7, 9, 11, 13 unsigned
-        // col 1 ,3 ..., 22 signed or non numeric
-        List<Integer> numericIndexWithAllColumn = Arrays.asList(0, 2, 4, 6, 7, 9, 11, 13);
+        // col 0, 1, 10, 11,,, non numeric
+        // col 2, 3, 4, 8 signed
+        // col 5, 6, 7, 9 unsigned
+        List<Integer> numericIndexWithAllColumn = Arrays.asList(2, 3, 4, 5, 6, 7, 8, 9);
         TableMapEventMetadata tableMapEventMetadata =
-            deserializer.deserialize(new ByteArrayInputStream(metadataIncludingUnknownFieldType), 23, 8, numericIndexWithAllColumn);
+            deserializer.deserialize(new ByteArrayInputStream(metadataIncludingUnknownFieldType), 23, 8,
+                                     numericIndexWithAllColumn);
 
         Map<Integer, Integer> expectedCharsetCollations = new LinkedHashMap<>();
         expectedCharsetCollations.put(6, 63);
@@ -44,11 +47,18 @@ public class TableMapEventMetadataDeserializerTest {
         expectedCharsetCollations.put(8, 63);
         expectedCharsetCollations.put(9, 63);
 
+        // metadataIncludingUnknownFieldType[2] = 29
+        // bin 00011101
+        // 2, 3, 4, 5(hit), 6(hit), 7(hit), 8, 9(hit
         BitSet expectAllColumnBitSet = new BitSet();
-        for(int i=0; i< numericIndexWithAllColumn.size(); i++)expectAllColumnBitSet.set(numericIndexWithAllColumn.get(i));
+        expectAllColumnBitSet.set(5);
+        expectAllColumnBitSet.set(6);
+        expectAllColumnBitSet.set(7);
+        expectAllColumnBitSet.set(9);
 
         assertEquals(tableMapEventMetadata.getDefaultCharset().getDefaultCharsetCollation(), 83);
-        assertEquals(tableMapEventMetadata.getDefaultCharset().getCharsetCollations(), expectedCharsetCollations);
+        assertEquals(tableMapEventMetadata.getDefaultCharset().getCharsetCollations(),
+                     expectedCharsetCollations);
         assertEquals(tableMapEventMetadata.getSignedness(), expectAllColumnBitSet);
     }
 }

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializerTest.java
@@ -48,8 +48,8 @@ public class TableMapEventMetadataDeserializerTest {
         expectedCharsetCollations.put(9, 63);
 
         // metadataIncludingUnknownFieldType[2] = 29
-        // bin 00011101
-        // 2, 3, 4, 5(hit), 6(hit), 7(hit), 8, 9(hit
+        // bin 00011101 (Numeric Column Order Byte)
+        // 2, 3, 4, 5(hit), 6(hit), 7(hit), 8, 9(hit)
         BitSet expectAllColumnBitSet = new BitSet();
         expectAllColumnBitSet.set(5);
         expectAllColumnBitSet.set(6);
@@ -59,6 +59,26 @@ public class TableMapEventMetadataDeserializerTest {
         assertEquals(tableMapEventMetadata.getDefaultCharset().getDefaultCharsetCollation(), 83);
         assertEquals(tableMapEventMetadata.getDefaultCharset().getCharsetCollations(),
                      expectedCharsetCollations);
+        assertEquals(tableMapEventMetadata.getSignedness(), expectAllColumnBitSet);
+    }
+
+    @Test
+    public void deserializeSignednessTest() throws IOException {
+        byte[] metadataIncludingSignedness = { 1, 1, -96};
+        TableMapEventMetadataDeserializer deserializer = new TableMapEventMetadataDeserializer();
+        // create table test( col1 int unsigned , col2 int, col3 varchar(30), col4 int unsigned)
+        List<Integer> numericIndexWithAllColumn = Arrays.asList(0, 1, 3);
+        TableMapEventMetadata tableMapEventMetadata =
+            deserializer.deserialize(new ByteArrayInputStream(metadataIncludingSignedness), 4, 3,
+                                     numericIndexWithAllColumn);
+
+        // metadataIncludingUnknownFieldType[2] = -96
+        // bin 10100000 (Numeric Column Order Byte)
+        // col1(hit), col2, col4(hit)
+        BitSet expectAllColumnBitSet = new BitSet();
+        expectAllColumnBitSet.set(0); // col1
+        expectAllColumnBitSet.set(3); // col4 we change Index 2 -> 3 from convertAllColumnOrder function
+
         assertEquals(tableMapEventMetadata.getSignedness(), expectAllColumnBitSet);
     }
 }


### PR DESCRIPTION
I was implementing optional_metadata field in table_map_event for [python-mysql-replication](https://github.com/julien-duponchelle/python-mysql-replication).

# Changes

- Add convertColumnOrder function 

# Reason 

optional metadata type *SIGNEDNESS*  case
The order of indices in the Inputstream corresponds to the order of numeric columns 
So we need to map the index  to all columns index(include non numeric type columns)


# Examples

SIGNEDNESS bit map now result is  **signedness={0, 2}**,  but we expect result should be **signedness={0, 3},**
Because test3 table column col1 and col4 are unsigned

AS-IS 

- sql  
```
create table test3( col1 int unsigned , col2 int, col3 varchar(30), col4 int unsigned)
insert into test3 values (1,2,3,4)
```
- application log 
```
Event{header=EventHeaderV4{timestamp=1692014933000, eventType=QUERY, serverId=1, headerLength=19, dataLength=193, nextPosition=2911, flags=0}, data=QueryEventData{threadId=1396, executionTime=0, errorCode=0, database='pymysqlreplication_test', sql='create table test3( col1 int unsigned , col2 int, col3 varchar(30), col4 int unsigned)'}}
Event{header=EventHeaderV4{timestamp=1692014936000, eventType=ANONYMOUS_GTID, serverId=1, headerLength=19, dataLength=60, nextPosition=2990, flags=0}, data=null}
Event{header=EventHeaderV4{timestamp=1692014936000, eventType=QUERY, serverId=1, headerLength=19, dataLength=75, nextPosition=3084, flags=8}, data=QueryEventData{threadId=1396, executionTime=0, errorCode=0, database='pymysqlreplication_test', sql='BEGIN'}}
Event{header=EventHeaderV4{timestamp=1692014936000, eventType=TABLE_MAP, serverId=1, headerLength=19, dataLength=86, nextPosition=3189, flags=0}, data=TableMapEventData{tableId=4555, database='pymysqlreplication_test', table='test3', columnTypes=3, 3, 15, 3, columnMetadata=0, 0, 120, 0, columnNullability={0, 1, 2, 3}, eventMetadata=TableMapEventMetadata{signedness={0, 2}, defaultCharset=255, charsetCollations=null, columnCharsets=null, columnNames=col1, col2, col3, col4, setStrValues=null, enumStrValues=null, geometryTypes=null, simplePrimaryKeys=null, primaryKeysWithPrefix=null, enumAndSetDefaultCharset=null, enumAndSetColumnCharsets=null,visibility={0, 1, 2, 3}}}}
```

TO-BE


- sql  
```
create table test3( col1 int unsigned , col2 int, col3 varchar(30), col4 int unsigned)
insert into test3 values (1,2,3,4)
```
- application log 
```
Event{header=EventHeaderV4{timestamp=1692014933000, eventType=QUERY, serverId=1, headerLength=19, dataLength=193, nextPosition=2911, flags=0}, data=QueryEventData{threadId=1396, executionTime=0, errorCode=0, database='pymysqlreplication_test', sql='create table test3( col1 int unsigned , col2 int, col3 varchar(30), col4 int unsigned)'}}
Event{header=EventHeaderV4{timestamp=1692014936000, eventType=ANONYMOUS_GTID, serverId=1, headerLength=19, dataLength=60, nextPosition=2990, flags=0}, data=null}
Event{header=EventHeaderV4{timestamp=1692014936000, eventType=QUERY, serverId=1, headerLength=19, dataLength=75, nextPosition=3084, flags=8}, data=QueryEventData{threadId=1396, executionTime=0, errorCode=0, database='pymysqlreplication_test', sql='BEGIN'}}
Event{header=EventHeaderV4{timestamp=1692014936000, eventType=TABLE_MAP, serverId=1, headerLength=19, dataLength=86, nextPosition=3189, flags=0}, data=TableMapEventData{tableId=4555, database='pymysqlreplication_test', table='test3', columnTypes=3, 3, 15, 3, columnMetadata=0, 0, 120, 0, columnNullability={0, 1, 2, 3}, eventMetadata=TableMapEventMetadata{signedness={0, 3}, defaultCharset=255, charsetCollations=null, columnCharsets=null, columnNames=col1, col2, col3, col4, setStrValues=null, enumStrValues=null, geometryTypes=null, simplePrimaryKeys=null, primaryKeysWithPrefix=null, enumAndSetDefaultCharset=null, enumAndSetColumnCharsets=null,visibility={0, 1, 2, 3}}}}
```



