### PR TITLE
Introduce support for MySQL 8 specific metadata on GTID events

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/GtidEventData.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/GtidEventData.java
@@ -24,14 +24,28 @@ public class GtidEventData implements EventData {
 
     private MySqlGtid gtid;
     private byte flags;
+    private long lastCommitted;
+    private long sequenceNumber;
+    private long immediateCommitTimestamp;
+    private long originalCommitTimestamp;
+    private long transactionLength;
+    private int immediateServerVersion;
+    private int originalServerVersion;
 
     @Deprecated
     public GtidEventData() {
     }
 
-    public GtidEventData(MySqlGtid gtid, byte flags) {
+    public GtidEventData(MySqlGtid gtid, byte flags, long lastCommitted, long sequenceNumber, long immediateCommitTimestamp, long originalCommitTimestamp, long transactionLength, int immediateServerVersion, int originalServerVersion) {
         this.gtid = gtid;
         this.flags = flags;
+        this.lastCommitted = lastCommitted;
+        this.sequenceNumber = sequenceNumber;
+        this.immediateCommitTimestamp = immediateCommitTimestamp;
+        this.originalCommitTimestamp = originalCommitTimestamp;
+        this.transactionLength = transactionLength;
+        this.immediateServerVersion = immediateServerVersion;
+        this.originalServerVersion = originalServerVersion;
     }
 
     @Deprecated
@@ -52,6 +66,34 @@ public class GtidEventData implements EventData {
         return flags;
     }
 
+    public long getLastCommitted() {
+        return lastCommitted;
+    }
+
+    public long getSequenceNumber() {
+        return sequenceNumber;
+    }
+
+    public long getImmediateCommitTimestamp() {
+        return immediateCommitTimestamp;
+    }
+
+    public long getOriginalCommitTimestamp() {
+        return originalCommitTimestamp;
+    }
+
+    public long getTransactionLength() {
+        return transactionLength;
+    }
+
+    public int getImmediateServerVersion() {
+        return immediateServerVersion;
+    }
+
+    public int getOriginalServerVersion() {
+        return originalServerVersion;
+    }
+
     @Deprecated
     public void setFlags(byte flags) {
         this.flags = flags;
@@ -61,6 +103,19 @@ public class GtidEventData implements EventData {
         final StringBuilder sb = new StringBuilder();
         sb.append("GtidEventData");
         sb.append("{flags=").append(flags).append(", gtid='").append(gtid).append('\'');
+        sb.append(", last_committed='").append(lastCommitted).append('\'');
+        sb.append(", sequence_number='").append(sequenceNumber).append('\'');
+        if (immediateCommitTimestamp != 0) {
+            sb.append(", immediate_commit_timestamp='").append(immediateCommitTimestamp).append('\'');
+            sb.append(", original_commit_timestamp='").append(originalCommitTimestamp).append('\'');
+        }
+        if (transactionLength != 0) {
+            sb.append(", transaction_length='").append(transactionLength).append('\'');
+            if (immediateServerVersion != 0) {
+               sb.append(", immediate_server_version='").append(immediateServerVersion).append('\'');
+               sb.append(", original_server_version='").append(originalServerVersion).append('\'');
+            }
+        }
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/GtidEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/GtidEventDataDeserializer.java
@@ -25,6 +25,22 @@ import java.util.UUID;
  * @author <a href="mailto:pprasse@actindo.de">Patrick Prasse</a>
  */
 public class GtidEventDataDeserializer implements EventDataDeserializer<GtidEventData> {
+    public static final int LOGICAL_TIMESTAMP_TYPECODE_LENGTH = 1;
+    // Type code used before the logical timestamps.
+    public static final int LOGICAL_TIMESTAMP_TYPECODE = 2;
+    public static final int LOGICAL_TIMESTAMP_LENGTH = 8;
+    // Length of immediate and original commit timestamps
+    public static final int IMMEDIATE_COMMIT_TIMESTAMP_LENGTH = 7;
+    public static final int ORIGINAL_COMMIT_TIMESTAMP_LENGTH = 7;
+    // Use 7 bytes out of which 1 bit is used as a flag.
+    public static final int ENCODED_COMMIT_TIMESTAMP_LENGTH = 55;
+    public static final int TRANSACTION_LENGTH_MIN_LENGTH = 1;
+    // Length of immediate and original server versions
+    public static final int IMMEDIATE_SERVER_VERSION_LENGTH = 4;
+    public static final int ORIGINAL_SERVER_VERSION_LENGTH = 4;
+    // Use 4 bytes out of which 1 bit is used as a flag.
+    public static final int ENCODED_SERVER_VERSION_LENGTH = 31;
+    public static final int UNDEFINED_SERVER_VERSION = 999999;
 
     @Override
     public GtidEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
@@ -33,13 +49,63 @@ public class GtidEventDataDeserializer implements EventDataDeserializer<GtidEven
         long sourceIdLeastSignificantBits = readLongBigEndian(inputStream);
         long transactionId = inputStream.readLong(8);
 
-        return new GtidEventData(
-            new MySqlGtid(
+        final MySqlGtid gtid = new MySqlGtid(
                 new UUID(sourceIdMostSignificantBits, sourceIdLeastSignificantBits),
                 transactionId
-            ),
-            flags
-        );
+            );
+
+        // MTR logical clock
+        long lastCommitted = 0;
+        long sequenceNumber = 0;
+        // ImmediateCommitTimestamp/OriginalCommitTimestamp are introduced in MySQL-8.0.1, see:
+        // https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html
+        long immediateCommitTimestamp = 0;
+        long originalCommitTimestamp = 0;
+        // Total transaction length (including this GTIDEvent), introduced in MySQL-8.0.2, see:
+        // https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-2.html
+        long transactionLength = 0;
+        // ImmediateServerVersion/OriginalServerVersion are introduced in MySQL-8.0.14, see
+        // https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-14.html
+        int immediateServerVersion = 0;
+        int originalServerVersion = 0;
+
+        // Logical timestamps - since MySQL 5.7.6
+        if (inputStream.peek() == LOGICAL_TIMESTAMP_TYPECODE) {
+            inputStream.skip(LOGICAL_TIMESTAMP_TYPECODE_LENGTH);
+            lastCommitted = inputStream.readLong(LOGICAL_TIMESTAMP_LENGTH);
+            sequenceNumber = inputStream.readLong(LOGICAL_TIMESTAMP_LENGTH);
+            // Immediate and original commit timestamps are introduced in MySQL-8.0.1
+            if (inputStream.available() >= IMMEDIATE_COMMIT_TIMESTAMP_LENGTH) {
+                immediateCommitTimestamp = inputStream.readLong(IMMEDIATE_COMMIT_TIMESTAMP_LENGTH);
+                // Check the MSB to determine how to populate the original commit timestamp
+                if ((immediateCommitTimestamp & (1L << ENCODED_COMMIT_TIMESTAMP_LENGTH)) != 0) {
+                    immediateCommitTimestamp &= ~(1L << ENCODED_COMMIT_TIMESTAMP_LENGTH);
+                    originalCommitTimestamp = inputStream.readLong(ORIGINAL_COMMIT_TIMESTAMP_LENGTH);
+                } else {
+                    // Transaction originated in the previous server eg. writer if direct connect
+                    originalCommitTimestamp = immediateCommitTimestamp;
+                }
+                // Total transaction length (including this GTIDEvent), introduced in MySQL-8.0.2
+                if (inputStream.available() >= TRANSACTION_LENGTH_MIN_LENGTH) {
+                    transactionLength = inputStream.readPackedInteger();
+                }
+                immediateServerVersion = UNDEFINED_SERVER_VERSION;
+                originalServerVersion = UNDEFINED_SERVER_VERSION;
+                // Immediate and original server versions are introduced in MySQL-8.0.14
+                if (inputStream.available() >= IMMEDIATE_SERVER_VERSION_LENGTH) {
+                    immediateServerVersion = inputStream.readInteger(IMMEDIATE_SERVER_VERSION_LENGTH);
+                    // Check the MSB to determine how to populate original server version
+                    if ((immediateServerVersion & (1L << ENCODED_SERVER_VERSION_LENGTH)) != 0) {
+                        immediateServerVersion &= ~(1L << ENCODED_SERVER_VERSION_LENGTH);
+                        originalServerVersion = inputStream.readInteger(ORIGINAL_SERVER_VERSION_LENGTH);
+                    } else {
+                        originalServerVersion = immediateServerVersion;
+                    }
+                }
+            }
+        }
+
+        return new GtidEventData(gtid, flags, lastCommitted, sequenceNumber, immediateCommitTimestamp, originalCommitTimestamp, transactionLength, immediateServerVersion, originalServerVersion);
     }
 
     private static long readLongBigEndian(ByteArrayInputStream input) throws IOException {
@@ -49,4 +115,5 @@ public class GtidEventDataDeserializer implements EventDataDeserializer<GtidEven
         }
         return result;
     }
+
 }

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/MysqlGtidEventDataDeserializerTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/MysqlGtidEventDataDeserializerTest.java
@@ -24,5 +24,89 @@ public class MysqlGtidEventDataDeserializerTest {
         ));
         assertEquals(data.getFlags(), 0x03);
         assertEquals(data.getMySqlGtid().toString(), "24bc7850-2c16-11e6-a073-0242ac110002:11");
+        assertEquals(data.getLastCommitted(), 0);
+        assertEquals(data.getSequenceNumber(), 0);
+        assertEquals(data.toString(), "GtidEventData{flags=3, gtid='24bc7850-2c16-11e6-a073-0242ac110002:11', last_committed='0', sequence_number='0'}");
+    }
+
+    @Test
+    public void testDeserializeMySQL801() throws IOException {
+        GtidEventData data = deserializer.deserialize(new ByteArrayInputStream(
+            new byte[]{
+                0x01, // flags
+                (byte) 0xaa, (byte) 0xe5, 0x7b, 0x2f, (byte) 0x8e, 0x44, 0x11, (byte) 0xee, // sourceId mostSignificantBits big endian
+                (byte) 0xa3, (byte) 0xd6, (byte) 0xa0, 0x36, (byte) 0xbc, (byte) 0xda, 0x1a, 0x41, // sourceId leastSignificantBits big endian
+                0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sequence little endian
+                0x02, // MTR
+                0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // last committed
+                0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sequence number
+                (byte) 0x97, (byte) 0xef, 0x0c, 0x25, 0x3f, 0x0b, 0x06, // commit timestamp
+            }
+        ));
+        assertEquals(data.getFlags(), 0x01);
+        assertEquals(data.getMySqlGtid().toString(), "aae57b2f-8e44-11ee-a3d6-a036bcda1a41:4");
+        assertEquals(data.getLastCommitted(), 3);
+        assertEquals(data.getSequenceNumber(), 4);
+        assertEquals(data.getImmediateCommitTimestamp(), 1701215692713879L);
+        assertEquals(data.getOriginalCommitTimestamp(), 1701215692713879L);
+        assertEquals(data.getTransactionLength(), 0);
+        assertEquals(data.getImmediateServerVersion(), 999999);
+        assertEquals(data.getOriginalServerVersion(), 999999);
+        assertEquals(data.toString(), "GtidEventData{flags=1, gtid='aae57b2f-8e44-11ee-a3d6-a036bcda1a41:4', last_committed='3', sequence_number='4', immediate_commit_timestamp='1701215692713879', original_commit_timestamp='1701215692713879'}");
+    }
+
+    @Test
+    public void testDeserializeMySQL802() throws IOException {
+        GtidEventData data = deserializer.deserialize(new ByteArrayInputStream(
+            new byte[]{
+                0x00, // flags
+                (byte) 0x99, 0x4a, (byte) 0xb8, 0x59, (byte) 0x8e, (byte) 0xa8, 0x11, (byte) 0xee, // sourceId mostSignificantBits big endian
+                (byte) 0xa5, 0x68, (byte) 0xa0, 0x36, (byte) 0xbc, (byte) 0xda, 0x1a, 0x41, // sourceId leastSignificantBits big endian
+                0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sequence little endian
+                0x02, // MTR
+                0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // last committed
+                0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sequence number
+                0x40, 0x55, 0x04, (byte) 0xc4, 0x48, 0x0b, 0x06, // commit timestamp
+                (byte) 0xfc, 0x34, 0x01, // transaction length
+            }
+        ));
+        assertEquals(data.getFlags(), 0x00);
+        assertEquals(data.getMySqlGtid().toString(), "994ab859-8ea8-11ee-a568-a036bcda1a41:3");
+        assertEquals(data.getLastCommitted(), 2);
+        assertEquals(data.getSequenceNumber(), 3);
+        assertEquals(data.getImmediateCommitTimestamp(), 1701257014433088L);
+        assertEquals(data.getOriginalCommitTimestamp(), 1701257014433088L);
+        assertEquals(data.getTransactionLength(), 308);
+        assertEquals(data.getImmediateServerVersion(), 999999);
+        assertEquals(data.getOriginalServerVersion(), 999999);
+        assertEquals(data.toString(), "GtidEventData{flags=0, gtid='994ab859-8ea8-11ee-a568-a036bcda1a41:3', last_committed='2', sequence_number='3', immediate_commit_timestamp='1701257014433088', original_commit_timestamp='1701257014433088', transaction_length='308', immediate_server_version='999999', original_server_version='999999'}");
+    }
+
+    @Test
+    public void testDeserializeMySQL810() throws IOException {
+        GtidEventData data = deserializer.deserialize(new ByteArrayInputStream(
+            new byte[]{
+                0x00, // flags
+                (byte) 0xbd, (byte) 0x97, (byte) 0x94, (byte) 0xe0, 0x1d, 0x65, 0x11, (byte) 0xed, // sourceId mostSignificantBits big endian
+                (byte) 0xa7, (byte) 0xe7, 0x0a, (byte) 0xdb, 0x30, 0x5b, 0x3a, 0x12, // sourceId leastSignificantBits big endian
+                0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sequence little endian
+                0x02, // MTR
+                0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // last committed
+                0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // sequence number
+                0x66, 0x29, (byte) 0xaa, 0x69, 0x55, 0x09, 0x06, // commit timestamp
+                (byte) 0xfc, 0x3b, 0x01, // transaction length
+                (byte) 0xe4, 0x38, 0x01, 0x00, // immediate server version
+            }
+        ));
+        assertEquals(data.getFlags(), 0x00);
+        assertEquals(data.getMySqlGtid().toString(), "bd9794e0-1d65-11ed-a7e7-0adb305b3a12:9");
+        assertEquals(data.getLastCommitted(), 7);
+        assertEquals(data.getSequenceNumber(), 8);
+        assertEquals(data.getImmediateCommitTimestamp(), 1699112309893478L);
+        assertEquals(data.getOriginalCommitTimestamp(), 1699112309893478L);
+        assertEquals(data.getTransactionLength(), 315);
+        assertEquals(data.getImmediateServerVersion(), 80100);
+        assertEquals(data.getOriginalServerVersion(), 80100);
+        assertEquals(data.toString(), "GtidEventData{flags=0, gtid='bd9794e0-1d65-11ed-a7e7-0adb305b3a12:9', last_committed='7', sequence_number='8', immediate_commit_timestamp='1699112309893478', original_commit_timestamp='1699112309893478', transaction_length='315', immediate_server_version='80100', original_server_version='80100'}");
     }
 }


### PR DESCRIPTION
## Why?

Getting actual high resolution millisecond binlog event time values is not supported by the binlog event header as the timestamp field is [represented as 4 bytes](https://github.com/percona/percona-server/blob/8.0/libbinlogevents/src/binlog_event.cpp#L196) and only [supports second resolution](https://github.com/percona/percona-server/blob/8.0/libbinlogevents/include/binlog_event.h#L612-L617). This basically cannot change without breaking binary compatibility and subsequently replication and binlog tooling as the [19 byte header offset](https://github.com/percona/percona-server/blob/8.0/libbinlogevents/include/binlog_event.h#L418) is hardcoded in so many spots.

We're pushing Shopify's CDC stack (this client and Debezium MySQL connector based) for lower latency to drive new business use cases, but need better timestamp resolution for the hop from writer -> ingested by our pipeline.

Related: [binlog event header struct](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_replication_binlog_event.html#sect_protocol_replication_binlog_event_header), [Maxwell issue](https://github.com/zendesk/maxwell/issues/1398), [higher level explanation](https://webyog.com/blog/monyog/replication-performance-enhancements-mysql-8/) of the MySQL 8 replication timestamps

## How?

The only other obvious alternative for MySQL > 8.0.1 is to extract additional metadata from the GTID event, specifically this set of metadata up to current MySQL 8 versions:

* [last_committed](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L996-L999), logical timestamp also supported since MySQL 5.7.6
* [sequence_number](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L1000-L1004), logical timestamp also supported since MySQL 5.7.6
* [immediate_commit_timestamp](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L1005-L1009), microsecond resolution timestamp from the immediate master (or equal to original_commit_timestamp if connecting to master) since MySQL 8.0.1
* [original_commit_timestamp](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L1005-L1009), microsecond resolution timestamp of the commit on the originating master (or equal to original_commit_timestamp if connecting to master) since MySQL 8.0.1
* [transaction_length](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L1015-L1020), byte offset of where this transaction ends (since MySQL 8.0.2)
* [immediate_server_version](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L1020-L1024) (since MySQL 8.0.14)
* [original_server_version](https://github.com/percona/percona-server/blob/c610bb54c2f122729741aa39866adc758fe23b4e/libbinlogevents/include/control_events.h#L1025-L1029) (since MySQL 8.0.14)

Aligned to be very close to the actual control event implementation in `libbinlogevents`

* `Gtid_event` in [header](https://github.com/percona/percona-server/blob/8.0/libbinlogevents/include/control_events.h#L944-L1228)
* `Gtid_event` in [source](https://github.com/percona/percona-server/blob/8.0/libbinlogevents/src/control_events.cpp#L439-L614)

## Binlog events used in the tests

@Naros  suggested to include a unit tests with payloads and assertions specific to these MySQL 8 versions: `8.0.1`, `8.0.2`, and > `8.0.14`

#### MySQL 8.0.1

```
# at 1069
#231128 23:54:52 server id 1  end_log_pos 1141 CRC32 0xc836869e 
# Position  Timestamp   Type   Master ID        Size      Master Pos    Flags 
#      42d cc 7d 66 65   21   01 00 00 00   48 00 00 00   75 04 00 00   00 00
#      440 01 aa e5 7b 2f 8e 44 11  ee a3 d6 a0 36 bc da 1a |......D.....6...|
#      450 41 04 00 00 00 00 00 00  00 02 03 00 00 00 00 00 |A...............|
#      460 00 00 04 00 00 00 00 00  00 00 97 ef 0c 25 3f 0b |................|
#      470 06 9e 86 36 c8                                   |...6.|
# 	GTID	last_committed=3	sequence_number=4	original_committed_timestamp=1701215692713879	immediate_commit_timestamp=1701215692713879
# original_commit_timestamp=1701215692713879 (2023-11-28 23:54:52.713879 WET)
```

#### MySQL 8.0.2

```
# at 770
#231129 11:23:34 server id 1  end_log_pos 845 CRC32 0xd6203da2 
# Position  Timestamp   Type   Master ID        Size      Master Pos    Flags 
#      302 36 1f 67 65   21   01 00 00 00   4b 00 00 00   4d 03 00 00   00 00
#      315 00 99 4a b8 59 8e a8 11  ee a5 68 a0 36 bc da 1a |..J.Y.....h.6...|
#      325 41 03 00 00 00 00 00 00  00 02 02 00 00 00 00 00 |A...............|
#      335 00 00 03 00 00 00 00 00  00 00 40 55 04 c4 48 0b |...........U..H.|
#      345 06 fc 34 01 a2 3d 20 d6                          |..4.....|
# 	GTID	last_committed=2	sequence_number=3	rbr_only=yes	original_committed_timestamp=1701257014433088	immediate_commit_timestamp=1701257014433088	transaction_length=308
/*!50718 SET TRANSACTION ISOLATION LEVEL READ COMMITTED*//*!*/;
# original_commit_timestamp=1701257014433088 (2023-11-29 11:23:34.433088 WET)
# immediate_commit_timestamp=1701257014433088 (2023-11-29 11:23:34.433088 WET)
```

#### MySQL 8.1.0

```
# at 2402
#231104 11:38:29 server id 1  end_log_pos 2481 CRC32 0xaa459aee
# Position  Timestamp   Type   Source ID        Size      Source Pos    Flags
# 00000962 75 65 46 65   21   01 00 00 00   4f 00 00 00   b1 09 00 00   00 00
# 00000975 00 bd 97 94 e0 1d 65 11  ed a7 e7 0a db 30 5b 3a |......e......0..|
# 00000985 12 09 00 00 00 00 00 00  00 02 07 00 00 00 00 00 |................|
# 00000995 00 00 08 00 00 00 00 00  00 00 66 29 aa 69 55 09 |..........f..iU.|
# 000009a5 06 fc 3b 01 e4 38 01 00  ee 9a 45 aa             |.....8....E.|
# 	GTID	last_committed=7	sequence_number=8	rbr_only=yes	original_committed_timestamp=1699112309893478	immediate_commit_timestamp=1699112309893478	transaction_length=315
```

Corresponding Debezium PR: https://github.com/debezium/debezium/pull/5036