### PR TITLE
hot fix optional metadata Extraction

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TableMapEventMetadataDeserializer.java
@@ -125,6 +125,7 @@ public class TableMapEventMetadataDeserializer {
                     break;
                 case ENUM_AND_SET_COLUMN_CHARSET:
                     result.setEnumAndSetColumnCharsets(readIntegers(inputStream));
+                    break;
                 case VISIBILITY:
                     result.setVisibility(readBooleanList(inputStream, nColumns));
                     break;


### PR DESCRIPTION
resolve #134 
without Break we can not go this Block
```
remainingBytes -= fieldLength;
```

So InputStream  goes wrong position.

@Naros @osheroff 
I think we need hotfix?



reproduce this Issue Step
```
CREATE TABLE `enum_test` (
  `int_column` int NOT NULL AUTO_INCREMENT,
  `smallint_column` int NOT NULL,
  `enum_column` enum('a','b','c') CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
  `datetime_column` datetime(6) DEFAULT CURRENT_TIMESTAMP(6),
  PRIMARY KEY (`int_column`)
) ENGINE=InnoDB AUTO_INCREMENT=864 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci


INSERT INTO `enum_test` (`smallint_column`, `enum_column`, `datetime_column`) 
VALUES 
(10, 'a', '2023-12-01 08:30:00'),
(20, 'b', '2023-12-01 09:45:00'),
(15, 'c', '2023-12-01 10:15:00');

alter table enum_test add column `userType` enum('INACTIVE','TERMINATED','ACTIVENONLICENSED','ACTIVE')  NOT NULL;


INSERT INTO `enum_test` (`smallint_column`, `enum_column`, `datetime_column`, `userType`) 
VALUES 
(30, 'a', '2023-12-01 12:00:00', 'INACTIVE'),
(25, 'c', '2023-12-01 13:30:00', 'ACTIVE'),
(35, 'b', '2023-12-01 14:45:00', 'TERMINATED'); <!--- error step----!>
```