### PR TITLE
bugfix: read long value when deserializing gtid transaction's length

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/GtidEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/GtidEventDataDeserializer.java
@@ -87,7 +87,7 @@ public class GtidEventDataDeserializer implements EventDataDeserializer<GtidEven
                 }
                 // Total transaction length (including this GTIDEvent), introduced in MySQL-8.0.2
                 if (inputStream.available() >= TRANSACTION_LENGTH_MIN_LENGTH) {
-                    transactionLength = inputStream.readPackedInteger();
+                    transactionLength = inputStream.readPackedLong();
                 }
                 immediateServerVersion = UNDEFINED_SERVER_VERSION;
                 originalServerVersion = UNDEFINED_SERVER_VERSION;

--- a/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
@@ -160,6 +160,19 @@ public class ByteArrayInputStream extends InputStream {
     }
 
     /**
+     * @see #readPackedNumber()
+     * @throws IOException in case of malformed number, eof, null
+     * @return long
+     */
+    public long readPackedLong() throws IOException {
+        Number number = readPackedNumber();
+        if (number == null) {
+            throw new IOException("Unexpected NULL where long should have been");
+        }
+        return number.longValue();
+    }
+
+    /**
      * Format (first-byte-based):<br>
      * 0-250 - The first byte is the number (in the range 0-250). No additional bytes are used.<br>
      * 251 - SQL NULL value<br>


### PR DESCRIPTION
fixing this issue
#140 