### PR TITLE
方法updateClientBinlogFilenameAndPosition和updateGtidSet等方法一样，可以被按需重写

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -1124,7 +1124,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
         return result;
     }
 
-    private void updateClientBinlogFilenameAndPosition(Event event) {
+    protected void updateClientBinlogFilenameAndPosition(Event event) {
         EventHeader eventHeader = event.getHeader();
         EventType eventType = eventHeader.getEventType();
         if (eventType == EventType.ROTATE) {


### PR DESCRIPTION
方法updateClientBinlogFilenameAndPosition和updateGtidSet等方法一样，可以被按需重写。 例如，重写该方法并添加对 binlogFileName 和 position 进行持久化。当服务宕机重启后可以从持久化中读取并继续。

例如：
```
        BinaryLogClient client = new BinaryLogClient(binLogProperties.getHost(), binLogProperties.getPort(),
                binLogProperties.getUsername(), binLogProperties.getPassword()) {

            @Override
            private void updateClientBinlogFilenameAndPosition(Event event) {
                super.updateClientBinlogFilenameAndPosition(event);
                // 将binlogFileName和position持久化记录，在服务宕机重启后读取并继续
                // （略）
            }
        };
```