### PR TITLE
Fix Cleaner leak: replace anonymous ThreadFactory with static nested class

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -918,14 +918,10 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void spawnKeepAliveThread() {
+        final String keepAliveThreadName = "blc-keepalive-" + hostname + ":" + port;
         final ExecutorService threadExecutor =
-            Executors.newSingleThreadExecutor(new ThreadFactory() {
-
-                @Override
-                public Thread newThread(Runnable runnable) {
-                    return newNamedThread(runnable, "blc-keepalive-" + hostname + ":" + port);
-                }
-            });
+            Executors.newSingleThreadExecutor(
+                new KeepAliveThreadFactory(this.threadFactory, keepAliveThreadName));
         try {
             keepAliveThreadExecutorLock.lock();
             threadExecutor.submit(new Runnable() {
@@ -1383,17 +1379,22 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     private void terminateKeepAliveThread() {
+        ExecutorService localExecutor;
         try {
             keepAliveThreadExecutorLock.lock();
-            ExecutorService keepAliveThreadExecutor = this.keepAliveThreadExecutor;
-            if ( keepAliveThreadExecutor == null ) {
+            localExecutor = this.keepAliveThreadExecutor;
+            if ( localExecutor == null ) {
                 return;
             }
-            keepAliveThreadExecutor.shutdownNow();
+            localExecutor.shutdownNow();
+            // Belt-and-suspenders: null the field so BinaryLogClient no longer strongly
+            // holds the executor after disconnect, even if a future refactor reintroduces
+            // an outer capture in KeepAliveThreadFactory.
+            this.keepAliveThreadExecutor = null;
         } finally {
             keepAliveThreadExecutorLock.unlock();
         }
-        while (!awaitTerminationInterruptibly(keepAliveThreadExecutor,
+        while (!awaitTerminationInterruptibly(localExecutor,
             Long.MAX_VALUE, TimeUnit.NANOSECONDS)) {
             // ignore
         }
@@ -1493,6 +1494,33 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
 
         public void onDisconnect(BinaryLogClient client) { }
 
+    }
+
+    /**
+     * Static so it cannot capture {@code BinaryLogClient.this}. An anonymous or non-static inner
+     * class declared in instance context implicitly captures the enclosing instance via a synthetic
+     * {@code this$0} field (JLS §15.9.5), regardless of whether the body references instance
+     * members. The JDK Cleaner registered by {@code AutoShutdownDelegatedExecutorService} holds
+     * the {@code ThreadPoolExecutor}, which holds its {@code threadFactory}. If that factory
+     * transitively reaches the executor (the Cleaner's referent), the referent is never
+     * phantom-reachable and the Cleaner action never runs, leaking ~1.6 MB per
+     * {@code BinaryLogClient} lifecycle.
+     */
+    private static final class KeepAliveThreadFactory implements ThreadFactory {
+        private final ThreadFactory delegate;
+        private final String threadName;
+
+        KeepAliveThreadFactory(ThreadFactory delegate, String threadName) {
+            this.delegate = delegate;
+            this.threadName = threadName;
+        }
+
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = delegate == null ? new Thread(runnable) : delegate.newThread(runnable);
+            thread.setName(threadName);
+            return thread;
+        }
     }
 
 }


### PR DESCRIPTION
An anonymous \`ThreadFactory\` declared in \`BinaryLogClient.spawnKeepAliveThread\` implicitly captures \`BinaryLogClient.this\` via a synthetic \`this\$0\` field (JLS §15.9.5), even though its body doesn't reference any instance members — because \`newNamedThread\` is an instance method.

This puts \`BinaryLogClient.this\` inside \`ThreadPoolExecutor.threadFactory\`. The JDK Cleaner holds a \`PhantomCleanableRef\` on \`AutoShutdownDelegatedExecutorService\` whose cleanup action closes over the \`ThreadPoolExecutor\`, creating a cycle:

\`\`\`
Cleaner.activeList
  -> PhantomCleanableRef.action
    -> ThreadPoolExecutor.threadFactory
      -> BinaryLogClient.this.keepAliveThreadExecutor
        -> AutoShutdownDelegatedExecutorService  ← the referent
\`\`\`

The referent is never phantom-reachable, so the \`PhantomCleanableRef\` never fires and one ~1.6 MB executor accumulates per reconnect.

The [\`java.lang.ref.Cleaner\` javadoc](https://docs.oracle.com/en/java/se/17/docs/api/java.base/java/lang/ref/Cleaner.html) explicitly warns: *"An inner class, anonymous or not, must not be used because it implicitly contains a reference to the outer instance, preventing it from becoming phantom reachable."*

**Fix:** replace the anonymous class with a \`private static final\` nested class \`KeepAliveThreadFactory\` that accepts the delegate \`ThreadFactory\` and thread name as constructor arguments. Bytecode-verified: no \`this\$0\` field.

<img width="782" height="152" alt="image" src="https://github.com/user-attachments/assets/25d91076-5b63-4f6d-b587-b24a6bb6e48b" />