### PR TITLE
support for binlog compressed payload (zstd) — streaming refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ but ended up as a complete rewrite. Key differences/features:
 - JMX-friendly
 - real-time stats
 - availability in Maven Central
-- no third-party dependencies
+- minimal third-party dependencies
+- transparent MySQL 8.0 `TRANSACTION_PAYLOAD` support for ZSTD-compressed transactions
 - test suite over different versions of MySQL releases
 
 > If you are looking for something similar in other languages - check out
@@ -83,6 +84,10 @@ kick off from a specific filename or position, use `client.setBinlogFilename(fil
 
 > `client.connect()` is blocking (meaning that client will listen for events in the current thread).
 `client.connect(timeout)`, on the other hand, spawns a separate thread.
+
+> MySQL 8.0 `binlog_transaction_compression` is supported transparently. `TRANSACTION_PAYLOAD`
+events are decompressed incrementally and delivered to listeners as their ordinary inner events,
+so consumers continue to see `QUERY`, `TABLE_MAP`, row, and commit events.
 
 
 #### MariaDB

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.zendesk</groupId>
     <artifactId>mysql-binlog-connector-java</artifactId>
-    <version>0.30.3</version>
+    <version>0.30.4-SNAPSHOT</version>
 
     <name>mysql-binlog-connector-java</name>
     <description>MySQL Binary Log connector</description>

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -64,6 +64,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
@@ -1130,32 +1131,36 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                     completeShutdown = true;
                     break;
                 }
-                Event event;
-                try {
-                    event = eventDeserializer.nextEvent(packetLength == MAX_PACKET_LENGTH ?
-                        new ByteArrayInputStream(readPacketSplitInChunks(inputStream, packetLength - 1)) :
-                        inputStream);
-                    if (event == null) {
-                        throw new EOFException();
-                    }
-                } catch (Exception e) {
-                    Throwable cause = e instanceof EventDataDeserializationException ? e.getCause() : e;
-                    if (cause instanceof EOFException || cause instanceof SocketException) {
-                        throw e;
+                ByteArrayInputStream eventStream = packetLength == MAX_PACKET_LENGTH ?
+                    new ByteArrayInputStream(new PacketPayloadInputStream(inputStream, packetLength - 1, true)) :
+                    inputStream;
+                // A TRANSACTION_PAYLOAD packet unpacks into several inner events; nextEvent() emits the
+                // first and buffers the rest, so keep pulling until this packet (and any payload it
+                // carried) is fully drained before reading the next one off the wire.
+                do {
+                    Event event;
+                    try {
+                        event = eventDeserializer.nextEvent(eventStream);
+                        if (event == null) {
+                            throw new EOFException();
+                        }
+                    } catch (Exception e) {
+                        Throwable cause = e instanceof EventDataDeserializationException ? e.getCause() : e;
+                        if (cause instanceof EOFException || cause instanceof SocketException) {
+                            throw e;
+                        }
+                        if (isConnected()) {
+                            for (LifecycleListener lifecycleListener : lifecycleListeners) {
+                                lifecycleListener.onEventDeserializationFailure(this, e);
+                            }
+                        }
+                        break;
                     }
                     if (isConnected()) {
-                        for (LifecycleListener lifecycleListener : lifecycleListeners) {
-                            lifecycleListener.onEventDeserializationFailure(this, e);
-                        }
+                        eventLastSeen = System.currentTimeMillis();
+                        handleEvent(event);
                     }
-                    continue;
-                }
-                if (isConnected()) {
-                    eventLastSeen = System.currentTimeMillis();
-                    updateGtidSet(event);
-                    notifyEventListeners(event);
-                    updateClientBinlogFilenameAndPosition(event);
-                }
+                } while (eventDeserializer.hasPendingTransactionPayloadEvent());
             }
         } catch (Exception e) {
             if (isConnected()) {
@@ -1174,16 +1179,70 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
         }
     }
 
-    private byte[] readPacketSplitInChunks(ByteArrayInputStream inputStream, int packetLength) throws IOException {
-        byte[] result = inputStream.read(packetLength);
-        int chunkLength;
-        do {
-            chunkLength = inputStream.readInteger(3);
-            inputStream.skip(1); // 1 byte for sequence
-            result = Arrays.copyOf(result, result.length + chunkLength);
-            inputStream.fill(result, result.length - chunkLength, chunkLength);
-        } while (chunkLength == Packet.MAX_LENGTH);
-        return result;
+    // TRANSACTION_PAYLOAD events are unpacked transparently by the EventDeserializer, so by the time
+    // an event reaches here it is always an ordinary event (an inner event of a compressed transaction
+    // is indistinguishable from a standalone one) and needs no special handling.
+    void handleEvent(Event event) {
+        updateGtidSet(event);
+        notifyEventListeners(event);
+        updateClientBinlogFilenameAndPosition(event);
+    }
+
+    static final class PacketPayloadInputStream extends InputStream {
+        private final ByteArrayInputStream inputStream;
+        private int chunkRemaining;
+        private boolean moreChunksExpected;
+
+        PacketPayloadInputStream(ByteArrayInputStream inputStream, int firstChunkRemaining,
+                boolean moreChunksExpected) {
+            this.inputStream = inputStream;
+            this.chunkRemaining = firstChunkRemaining;
+            this.moreChunksExpected = moreChunksExpected;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (!ensureChunkAvailable()) {
+                return -1;
+            }
+            int read = inputStream.read();
+            chunkRemaining--;
+            return read;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (b == null) {
+                throw new NullPointerException();
+            } else if (off < 0 || len < 0 || len > b.length - off) {
+                throw new IndexOutOfBoundsException();
+            } else if (len == 0) {
+                return 0;
+            }
+            if (!ensureChunkAvailable()) {
+                return -1;
+            }
+            int read = inputStream.read(b, off, Math.min(len, chunkRemaining));
+            if (read == -1) {
+                throw new EOFException("Unexpected end of packet; " + chunkRemaining +
+                    " bytes still expected in the current chunk");
+            }
+            chunkRemaining -= read;
+            return read;
+        }
+
+        private boolean ensureChunkAvailable() throws IOException {
+            while (chunkRemaining == 0) {
+                if (!moreChunksExpected) {
+                    return false;
+                }
+                int chunkLength = inputStream.readInteger(3);
+                inputStream.skip(1); // 1 byte for sequence
+                chunkRemaining = chunkLength;
+                moreChunksExpected = chunkLength == Packet.MAX_LENGTH;
+            }
+            return true;
+        }
     }
 
     private void updateClientBinlogFilenameAndPosition(Event event) {

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/TransactionPayloadEventData.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/TransactionPayloadEventData.java
@@ -1,14 +1,16 @@
 package com.github.shyiko.mysql.binlog.event;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 
 
 public class TransactionPayloadEventData implements EventData {
-    private int payloadSize;
+    private long payloadSize;
     private long uncompressedSize;
     private int compressionType;
     private byte[] payload;
-    private ArrayList<Event> uncompressedEvents;
+    private transient InputStream payloadInputStream;
+    private ArrayList<Event> uncompressedEvents = new ArrayList<Event>();
 
     public ArrayList<Event> getUncompressedEvents() {
         return uncompressedEvents;
@@ -19,10 +21,22 @@ public class TransactionPayloadEventData implements EventData {
     }
 
     public int getPayloadSize() {
-        return payloadSize;
+        if (payloadSize > Integer.MAX_VALUE) {
+            throw new IllegalStateException("Transaction payload size " + payloadSize +
+                " exceeds the maximum int value");
+        }
+        return (int) payloadSize;
     }
 
     public void setPayloadSize(int payloadSize) {
+        this.payloadSize = payloadSize;
+    }
+
+    public long getPayloadSizeLong() {
+        return payloadSize;
+    }
+
+    public void setPayloadSize(long payloadSize) {
         this.payloadSize = payloadSize;
     }
 
@@ -50,6 +64,14 @@ public class TransactionPayloadEventData implements EventData {
         this.payload = payload;
     }
 
+    public InputStream getPayloadInputStream() {
+        return payloadInputStream;
+    }
+
+    public void setPayloadInputStream(InputStream payloadInputStream) {
+        this.payloadInputStream = payloadInputStream;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -57,7 +79,7 @@ public class TransactionPayloadEventData implements EventData {
         sb.append("{compression_type=").append(compressionType).append(", payload_size=").append(payloadSize).append(", uncompressed_size='").append(uncompressedSize).append('\'');
         sb.append(", payload: ");
         sb.append("\n");
-        for (Event e : uncompressedEvents) {
+        for (Event e : getUncompressedEvents()) {
             sb.append(e.toString());
             sb.append("\n");
         }

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
@@ -48,6 +48,10 @@ public class EventDeserializer {
     private EventDataDeserializer tableMapEventDataDeserializer;
     private EventDataDeserializer formatDescEventDataDeserializer;
 
+    // Streams the inner events of a TRANSACTION_PAYLOAD out one per nextEvent() call (see nextEvent),
+    // so a compressed transaction is unpacked transparently without materializing its whole image.
+    private final TransactionPayloadEventBuffer transactionPayloadBuffer = new TransactionPayloadEventBuffer();
+
     public EventDeserializer() {
         this(new EventHeaderV4Deserializer(), new NullEventDataDeserializer());
     }
@@ -217,6 +221,10 @@ public class EventDeserializer {
             deserializer.setDeserializeIntegerAsByteArray(
                 compatibilitySet.contains(CompatibilityMode.INTEGER_AS_BYTE_ARRAY)
             );
+        } else if (eventDataDeserializer instanceof TransactionPayloadEventDataDeserializer) {
+            // Inner events of a transaction payload are parsed by a nested deserializer; carry the
+            // compatibility modes through to it so they apply to those events as well.
+            ((TransactionPayloadEventDataDeserializer) eventDataDeserializer).setCompatibilityMode(compatibilitySet);
         }
     }
 
@@ -226,6 +234,14 @@ public class EventDeserializer {
 	 * @throws IOException if connection gets closed
      */
     public Event nextEvent(ByteArrayInputStream inputStream) throws IOException {
+        // A previously-read TRANSACTION_PAYLOAD is unpacked transparently: emit its remaining inner
+        // events (or surface a deferred unpack failure) before reading the next event off the stream.
+        if (transactionPayloadBuffer.hasPending()) {
+            Event innerEvent = transactionPayloadBuffer.next();
+            if (innerEvent != null) {
+                return innerEvent;
+            }
+        }
         if (inputStream.peek() == -1) {
             return null;
         }
@@ -238,14 +254,34 @@ public class EventDeserializer {
             case TABLE_MAP:
                 eventData = deserializeTableMapEventData(inputStream, eventHeader);
                 break;
-            case TRANSACTION_PAYLOAD:
+            case TRANSACTION_PAYLOAD: {
+                EventDataDeserializer deserializer = getEventDataDeserializer(EventType.TRANSACTION_PAYLOAD);
+                if (deserializer instanceof TransactionPayloadEventDataDeserializer) {
+                    // Stream the payload's inner events out as ordinary top-level events: the buffer
+                    // returns the first one now and holds the rest for subsequent nextEvent() calls.
+                    return transactionPayloadBuffer.open(
+                        (TransactionPayloadEventDataDeserializer) deserializer, inputStream, eventHeader,
+                        checksumLength);
+                }
+                // A custom deserializer handles the payload its own way; surface the TRANSACTION_PAYLOAD
+                // event as-is (pre-streaming behavior), with any inner table maps registered below.
                 eventData = deserializeTransactionPayloadEventData(inputStream, eventHeader);
                 break;
+            }
             default:
                 EventDataDeserializer eventDataDeserializer = getEventDataDeserializer(eventHeader.getEventType());
                 eventData = deserializeEventData(inputStream, eventHeader, eventDataDeserializer);
         }
         return new Event(eventHeader, eventData);
+    }
+
+    /**
+     * @return {@code true} while a previously-read TRANSACTION_PAYLOAD still has inner events (or a
+     * deferred unpack failure) to emit, so a packet-oriented reader knows not to pull the next packet
+     * yet.
+     */
+    public boolean hasPendingTransactionPayloadEvent() {
+        return transactionPayloadBuffer.hasPending();
     }
 
     private EventData deserializeFormatDescriptionEventData(ByteArrayInputStream inputStream, EventHeader eventHeader)
@@ -293,9 +329,12 @@ public class EventDeserializer {
         TransactionPayloadEventData transactionPayloadEventData = (TransactionPayloadEventData) eventData;
 
         /**
-         * Handling for TABLE_MAP events withing the transaction payload event. This is to ensure that for the table map
-         * events within the transaction payload, the target table id and the event gets added to the
-         * tableMapEventByTableId map. This is map is later used while deserializing rows.
+         * Handling for TABLE_MAP events within the transaction payload event, so a row event in the
+         * payload resolves against its table map. Inner events are now parsed lazily and streamed
+         * (see {@link TransactionPayloadEventBuffer}), each payload getting a self-contained inner
+         * deserializer whose own table-map cache is populated in stream order, so this loop is a no-op
+         * in the streaming path (getUncompressedEvents() is empty). It is kept for a custom
+         * TRANSACTION_PAYLOAD deserializer that still materializes inner events eagerly.
          */
         for (Event event : transactionPayloadEventData.getUncompressedEvents()) {
             if (event.getHeader().getEventType() == EventType.TABLE_MAP && event.getData() != null) {
@@ -329,11 +368,15 @@ public class EventDeserializer {
 
     private EventData deserializeEventData(ByteArrayInputStream inputStream, EventHeader eventHeader,
             EventDataDeserializer eventDataDeserializer) throws EventDataDeserializationException {
-        int eventBodyLength = (int) eventHeader.getDataLength() - checksumLength;
+        long eventBodyLength = eventHeader.getDataLength() - checksumLength;
         EventData eventData;
         try {
             inputStream.enterBlock(eventBodyLength);
             try {
+                if (eventBodyLength > Integer.MAX_VALUE) {
+                    throw new IOException("Event data length " + eventBodyLength +
+                        " exceeds the maximum supported size of " + Integer.MAX_VALUE + " bytes");
+                }
                 eventData = eventDataDeserializer.deserialize(inputStream);
             } finally {
                 inputStream.skipToTheEndOfTheBlock();

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TransactionPayloadEventBuffer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TransactionPayloadEventBuffer.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2013 Stanley Shyiko
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.shyiko.mysql.binlog.event.deserialization;
+
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeader;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+
+import java.io.IOException;
+
+/**
+ * Holds the inner events of a single {@code TRANSACTION_PAYLOAD} that is being unpacked, handing them
+ * out one per call so a compressed transaction is streamed through with bounded memory rather than
+ * materialized whole (its uncompressed image may exceed the 2GB {@code byte[]} limit or simply not fit
+ * in heap).
+ *
+ * <p>{@link EventDeserializer} keeps one instance and consults {@link #hasPending()} before reading the
+ * underlying stream: while a payload is in flight its remaining inner events (and any deferred unpack
+ * failure) are emitted through {@link #next()}; only once it is drained does the deserializer read the
+ * next event off the stream. {@link #open} starts a payload and returns its first inner event. This is
+ * the state machine that would otherwise live directly in {@link EventDeserializer}.
+ */
+class TransactionPayloadEventBuffer {
+
+    private TransactionPayloadEventDataDeserializer.InnerEventIterator iterator;
+    private EventHeader eventHeader;
+    private ByteArrayInputStream inputStream;
+    private int checksumLength;
+    private IOException deferredFailure;
+
+    /**
+     * @return {@code true} while a payload opened earlier still has inner events (or a deferred unpack
+     * failure) to emit.
+     */
+    boolean hasPending() {
+        return iterator != null || deferredFailure != null;
+    }
+
+    /**
+     * Begins unpacking the {@code TRANSACTION_PAYLOAD} whose body is next on {@code inputStream} and
+     * returns its first inner event. The compressed payload is consumed from {@code inputStream}
+     * incrementally as inner events are pulled (see {@link #next()}), so nothing is prefetched; the
+     * stream is left positioned at the end of the whole envelope (payload + checksum) only once the
+     * payload has been drained.
+     *
+     * @return the first inner event, or - for the degenerate case of a payload carrying no inner events
+     * - the {@link TransactionPayloadEventData} envelope itself, so the caller never mistakes an empty
+     * payload for end-of-stream.
+     */
+    Event open(TransactionPayloadEventDataDeserializer deserializer, ByteArrayInputStream inputStream,
+            EventHeader eventHeader, int checksumLength) throws IOException {
+        TransactionPayloadEventData eventData = deserializeEnvelope(deserializer, inputStream, eventHeader,
+            checksumLength);
+        this.eventHeader = eventHeader;
+        this.inputStream = inputStream;
+        this.checksumLength = checksumLength;
+        try {
+            iterator = deserializer.iterator(eventData);
+            // The cursor now owns the bytes it needs; drop the compressed copy so the event (which a
+            // reader typically pins until the next one arrives) does not also retain the whole payload.
+            eventData.setPayload(null);
+            eventData.setPayloadInputStream(null);
+            Event innerEvent = next();
+            if (innerEvent != null) {
+                return innerEvent;
+            }
+        } catch (IOException | RuntimeException e) {
+            try {
+                close();
+            } catch (IOException closeFailure) {
+                e.addSuppressed(closeFailure);
+            }
+            throw e;
+        }
+        // A payload with no inner events is not expected from MySQL; if it happens, surface the envelope
+        // itself rather than returning null (which a reader would mistake for end-of-stream).
+        return new Event(eventHeader, eventData);
+    }
+
+    /**
+     * @return the next buffered inner event, or {@code null} once the current payload is fully drained
+     * (at which point the deserializer resumes reading the underlying stream).
+     * @throws IOException re-raising a deferred close failure, or wrapping a decompression /
+     * inner-event parse failure.
+     */
+    Event next() throws IOException {
+        if (deferredFailure != null) {
+            IOException failure = deferredFailure;
+            deferredFailure = null;
+            throw failure;
+        }
+        if (iterator == null) {
+            return null;
+        }
+        Event innerEvent;
+        try {
+            innerEvent = iterator.next();
+        } catch (IOException | RuntimeException e) {
+            // A decompression/parse failure partway through the payload cannot be skipped cleanly the
+            // way a standalone undeserializable event can (earlier inner events were already emitted).
+            // Surface it as a plain deserialization failure - never an EOFException/SocketException - so
+            // the reader reports it and moves on instead of treating it as a transport failure and
+            // reconnecting only to refetch and re-fail on the same payload.
+            IOException failure = new IOException("Failed to deserialize inner event of TRANSACTION_PAYLOAD", e);
+            try {
+                close();
+            } catch (IOException closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
+            throw failure;
+        }
+        if (innerEvent == null) {
+            close();
+            return null;
+        }
+        stampOuterEventCoordinates(eventHeader, innerEvent);
+        if (iterator.isExhausted()) {
+            try {
+                close();
+            } catch (IOException e) {
+                // Hand back the (valid) event we already hold and report the close/skip failure on the
+                // next call, so inner events stay in order.
+                deferredFailure = e;
+            }
+        }
+        return innerEvent;
+    }
+
+    // Parses just the on-the-wire payload header (compression type / sizes), leaving the compressed
+    // payload on the stream for the iterator to decompress lazily. On failure the envelope is drained
+    // (payload + checksum) so the stream stays aligned for the next event.
+    private TransactionPayloadEventData deserializeEnvelope(TransactionPayloadEventDataDeserializer deserializer,
+            ByteArrayInputStream inputStream, EventHeader eventHeader, int checksumLength)
+            throws EventDataDeserializationException {
+        long eventBodyLength = eventHeader.getDataLength() - checksumLength;
+        try {
+            inputStream.enterBlock(eventBodyLength);
+            return deserializer.deserialize(inputStream, false);
+        } catch (IOException e) {
+            try {
+                inputStream.skipToTheEndOfTheBlock();
+                inputStream.skip(checksumLength);
+            } catch (IOException skipFailure) {
+                e.addSuppressed(skipFailure);
+            }
+            throw new EventDataDeserializationException(eventHeader, e);
+        }
+    }
+
+    private void close() throws IOException {
+        IOException failure = null;
+        if (iterator != null) {
+            try {
+                iterator.close();
+            } catch (IOException e) {
+                failure = e;
+            }
+            iterator = null;
+        }
+        try {
+            finishBlock();
+        } catch (IOException e) {
+            if (failure == null) {
+                failure = e;
+            } else {
+                failure.addSuppressed(e);
+            }
+        } finally {
+            eventHeader = null;
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    // Drains any payload bytes the decompressor did not consume, then the checksum, leaving the stream
+    // positioned at the start of the next event.
+    private void finishBlock() throws IOException {
+        if (inputStream != null) {
+            try {
+                inputStream.skipToTheEndOfTheBlock();
+                inputStream.skip(checksumLength);
+            } finally {
+                inputStream = null;
+                checksumLength = 0;
+            }
+        }
+    }
+
+    // Inner events are decoded from the payload's own byte stream, so their headers carry positions
+    // relative to that stream. Restamp each one with the outer envelope's length and next-position so a
+    // consumer tracking getBinlogPosition() advances to the transaction boundary, as for any event.
+    private static void stampOuterEventCoordinates(EventHeader outerHeader, Event innerEvent) {
+        EventHeader innerHeader = innerEvent.getHeader();
+        if (outerHeader instanceof EventHeaderV4 && innerHeader instanceof EventHeaderV4) {
+            EventHeaderV4 outerHeaderV4 = (EventHeaderV4) outerHeader;
+            EventHeaderV4 innerHeaderV4 = (EventHeaderV4) innerHeader;
+            innerHeaderV4.setEventLength(outerHeaderV4.getEventLength());
+            innerHeaderV4.setNextPosition(outerHeaderV4.getNextPosition());
+        }
+    }
+}

--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TransactionPayloadEventDataDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/TransactionPayloadEventDataDeserializer.java
@@ -20,8 +20,11 @@ import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
 import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 
+import java.io.Closeable;
+import java.io.EOFException;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.io.InputStream;
+import java.util.EnumSet;
 
 /**
  * @author <a href="mailto:somesh.malviya@booking.com">Somesh Malviya</a>
@@ -33,10 +36,26 @@ public class TransactionPayloadEventDataDeserializer implements EventDataDeseria
     public static final int OTW_PAYLOAD_SIZE_FIELD = 1;
     public static final int OTW_PAYLOAD_COMPRESSION_TYPE_FIELD = 2;
     public static final int OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD = 3;
+    public static final int COMPRESSION_TYPE_ZSTD = 0;
+    public static final int COMPRESSION_TYPE_NONE = 255;
+
+    private EventDeserializer.CompatibilityMode[] compatibilityModes = new EventDeserializer.CompatibilityMode[0];
+
+    void setCompatibilityMode(EnumSet<EventDeserializer.CompatibilityMode> compatibilitySet) {
+        compatibilityModes = compatibilitySet.toArray(
+            new EventDeserializer.CompatibilityMode[compatibilitySet.size()]
+        );
+    }
 
     @Override
     public TransactionPayloadEventData deserialize(ByteArrayInputStream inputStream) throws IOException {
+        return deserialize(inputStream, true);
+    }
+
+    TransactionPayloadEventData deserialize(ByteArrayInputStream inputStream, boolean materializePayload)
+            throws IOException {
         TransactionPayloadEventData eventData = new TransactionPayloadEventData();
+        eventData.setCompressionType(COMPRESSION_TYPE_NONE);
         // Read the header fields from the event data
         while (inputStream.available() > 0) {
             int fieldType = 0;
@@ -49,21 +68,21 @@ public class TransactionPayloadEventDataDeserializer implements EventDataDeseria
             if (fieldType == OTW_PAYLOAD_HEADER_END_MARK) {
                 break;
             }
-            // Read the size of the field (use readPackedLong to support large field sizes)
+            // Read the size of the field
             if (inputStream.available() >= 1) {
                 fieldLen = inputStream.readPackedInteger();
             }
             switch (fieldType) {
                 case OTW_PAYLOAD_SIZE_FIELD:
-                    // Fetch the payload size
-                    eventData.setPayloadSize(inputStream.readPackedInteger());
+                    // Fetch the payload (compressed) size
+                    eventData.setPayloadSize(inputStream.readPackedLong());
                     break;
                 case OTW_PAYLOAD_COMPRESSION_TYPE_FIELD:
                     // Fetch the compression type
                     eventData.setCompressionType(inputStream.readPackedInteger());
                     break;
                 case OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD:
-                    // Fetch the uncompressed size
+                    // Fetch the uncompressed size (may exceed 2GB; inner events are streamed)
                     eventData.setUncompressedSize(inputStream.readPackedLong());
                     break;
                 default:
@@ -74,33 +93,200 @@ public class TransactionPayloadEventDataDeserializer implements EventDataDeseria
         }
         if (eventData.getUncompressedSize() == 0) {
             // Default the uncompressed to the payload size
-            eventData.setUncompressedSize(eventData.getPayloadSize());
+            eventData.setUncompressedSize(eventData.getPayloadSizeLong());
         }
 
-        eventData.setPayload(inputStream.read(eventData.getPayloadSize()));
+        // Fail fast on an unsupported compression type, before consuming the payload, so it
+        // surfaces as a clean deserialization failure rather than later during inner-event streaming.
+        requireSupportedCompressionType(eventData.getCompressionType());
+        if (eventData.getPayloadSizeLong() < 0) {
+            throw new IOException("Invalid negative transaction payload size: " +
+                eventData.getPayloadSizeLong());
+        }
 
-        // Use streaming decompression to handle uncompressed sizes up to 4GB
-        // This avoids hitting Java's 2GB array limit by processing events as they're decompressed
-        ArrayList<Event> decompressedEvents = getDecompressedEvents(eventData);
+        if (materializePayload && eventData.getPayloadSizeLong() <= Integer.MAX_VALUE) {
+            eventData.setPayload(inputStream.read((int) eventData.getPayloadSizeLong()));
+        } else {
+            eventData.setPayloadInputStream(new BoundedInputStream(inputStream, eventData.getPayloadSizeLong()));
+        }
 
-        eventData.setUncompressedEvents(decompressedEvents);
-
+        // Inner events are intentionally NOT materialized here: a compressed transaction is bounded
+        // by the transaction size, not by any per-event limit, so eagerly parsing every inner event
+        // into a list would put the whole transaction's object graph on the heap at once. They are
+        // surfaced one at a time through iterator(); uncompressedEvents stays empty.
         return eventData;
     }
 
-    private static ArrayList<Event> getDecompressedEvents(TransactionPayloadEventData eventData) throws IOException {
-        ArrayList<Event> decompressedEvents = new ArrayList<>();
-        EventDeserializer transactionPayloadEventDeserializer = new EventDeserializer();
+    /**
+     * Opens a single-pass cursor over the transaction's inner events, decompressing the payload
+     * incrementally. Peak memory is bounded by the decompressor's buffers plus one inner event, so a
+     * transaction whose compressed or uncompressed image exceeds the 2GB {@code byte[]} limit is
+     * streamed through instead of being materialized whole. The returned iterator must be
+     * {@link InnerEventIterator#close() closed} to release the native decompressor.
+     */
+    public InnerEventIterator iterator(TransactionPayloadEventData eventData) throws IOException {
+        EventDeserializer innerEventDeserializer = new EventDeserializer();
+        setCompatibilityMode(innerEventDeserializer);
+        ByteArrayInputStream stream = new ByteArrayInputStream(getDecompressedInputStream(eventData));
+        return new InnerEventIterator(innerEventDeserializer, stream, eventData.getUncompressedSize());
+    }
 
-        try (ZstdInputStream zstdInputStream = new ZstdInputStream(new java.io.ByteArrayInputStream(eventData.getPayload()))) {
-            ByteArrayInputStream destinationInputStream = new ByteArrayInputStream(zstdInputStream);
+    private static void requireSupportedCompressionType(int compressionType) throws IOException {
+        if (compressionType != COMPRESSION_TYPE_ZSTD && compressionType != COMPRESSION_TYPE_NONE) {
+            throw new IOException("Unsupported binlog_transaction_compression type: " +
+                compressionType + " (only ZSTD and NONE are supported)");
+        }
+    }
 
-            Event internalEvent = transactionPayloadEventDeserializer.nextEvent(destinationInputStream);
-            while(internalEvent != null) {
-                decompressedEvents.add(internalEvent);
-                internalEvent = transactionPayloadEventDeserializer.nextEvent(destinationInputStream);
+    private InputStream getDecompressedInputStream(TransactionPayloadEventData eventData) throws IOException {
+        InputStream payloadInputStream = eventData.getPayloadInputStream();
+        if (payloadInputStream == null) {
+            byte[] payload = eventData.getPayload();
+            if (payload == null) {
+                throw new IOException("Transaction payload is not available");
+            }
+            payloadInputStream = new java.io.ByteArrayInputStream(payload);
+        }
+        switch (eventData.getCompressionType()) {
+            case COMPRESSION_TYPE_ZSTD:
+                return new ZstdInputStream(payloadInputStream);
+            case COMPRESSION_TYPE_NONE:
+                return payloadInputStream;
+            default:
+                throw new IOException("Unsupported binlog_transaction_compression type: " +
+                    eventData.getCompressionType() + " (only ZSTD and NONE are supported)");
+        }
+    }
+
+    /**
+     * Presents exactly {@code length} bytes from an underlying stream without owning/closing it.
+     */
+    static final class BoundedInputStream extends InputStream {
+        private final InputStream inputStream;
+        private long remaining;
+
+        BoundedInputStream(InputStream inputStream, long length) {
+            this.inputStream = inputStream;
+            this.remaining = length;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (remaining == 0) {
+                return -1;
+            }
+            int read = inputStream.read();
+            if (read == -1) {
+                throw new EOFException("Unexpected end of transaction payload; " + remaining +
+                    " bytes still expected");
+            }
+            remaining--;
+            return read;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (remaining == 0) {
+                return -1;
+            }
+            int read = inputStream.read(b, off, (int) Math.min((long) len, remaining));
+            if (read == -1) {
+                throw new EOFException("Unexpected end of transaction payload; " + remaining +
+                    " bytes still expected");
+            }
+            remaining -= read;
+            return read;
+        }
+
+        @Override
+        public int available() throws IOException {
+            return (int) Math.min((long) inputStream.available(), Math.min(remaining, (long) Integer.MAX_VALUE));
+        }
+
+        @Override
+        public void close() throws IOException {
+            // Do not close the owner stream; EventDeserializer drains/skips to the event boundary.
+        }
+    }
+
+    private void setCompatibilityMode(EventDeserializer eventDeserializer) {
+        if (compatibilityModes.length > 0) {
+            EventDeserializer.CompatibilityMode first = compatibilityModes[0];
+            EventDeserializer.CompatibilityMode[] rest =
+                new EventDeserializer.CompatibilityMode[compatibilityModes.length - 1];
+            System.arraycopy(compatibilityModes, 1, rest, 0, rest.length);
+            eventDeserializer.setCompatibilityMode(first, rest);
+        }
+    }
+
+    /**
+     * Single-pass cursor over the inner events of a {@link TransactionPayloadEventData}. Each
+     * {@link #next()} decompresses and parses just enough of the payload to return one event;
+     * {@code null} signals the end of the transaction, at which point the cursor closes itself.
+     */
+    public static final class InnerEventIterator implements Closeable {
+        private EventDeserializer eventDeserializer;
+        private ByteArrayInputStream inputStream;
+        private final long uncompressedSize;
+        private boolean exhausted;
+
+        InnerEventIterator(EventDeserializer eventDeserializer, ByteArrayInputStream inputStream,
+                long uncompressedSize) {
+            this.eventDeserializer = eventDeserializer;
+            this.inputStream = inputStream;
+            this.uncompressedSize = uncompressedSize;
+        }
+
+        /**
+         * @return the next inner event, or {@code null} once the transaction is exhausted (which
+         * also closes the cursor).
+         * @throws IOException on a decompression or inner-event parse failure
+         */
+        public Event next() throws IOException {
+            if (inputStream == null) {
+                return null;
+            }
+            if (inputStream.getLongPosition() == uncompressedSize) {
+                exhausted = true;
+                close();
+                return null;
+            }
+            Event event = eventDeserializer.nextEvent(inputStream);
+            if (event == null) {
+                exhausted = true;
+                close();
+            } else {
+                long position = inputStream.getLongPosition();
+                if (position > uncompressedSize) {
+                    IOException failure = new IOException("Inner events consumed " + position +
+                        " bytes, exceeding transaction payload uncompressed size " + uncompressedSize);
+                    try {
+                        close();
+                    } catch (IOException closeFailure) {
+                        failure.addSuppressed(closeFailure);
+                    }
+                    throw failure;
+                }
+                exhausted = position == uncompressedSize;
+            }
+            return event;
+        }
+
+        boolean isExhausted() {
+            return exhausted || inputStream == null;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (inputStream != null) {
+                try {
+                    // Closes the underlying (zstd) stream, releasing its native decompression context.
+                    inputStream.close();
+                } finally {
+                    inputStream = null;
+                    eventDeserializer = null;
+                }
             }
         }
-        return decompressedEvents;
     }
 }

--- a/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/io/ByteArrayInputStream.java
@@ -27,9 +27,9 @@ public class ByteArrayInputStream extends InputStream {
 
     private InputStream inputStream;
     private int peek = -1;
-    private int pos, markPosition;
-    private int blockLength = -1;
-    private int initialBlockLength = -1;
+    private long pos, markPosition;
+    private long blockLength = -1;
+    private long initialBlockLength = -1;
 
     public ByteArrayInputStream(InputStream inputStream) {
         this.inputStream = inputStream;
@@ -201,7 +201,7 @@ public class ByteArrayInputStream extends InputStream {
     @Override
     public int available() throws IOException {
         if (blockLength != -1) {
-            return blockLength;
+            return blockLength > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) blockLength;
         }
         return inputStream.available();
     }
@@ -234,9 +234,12 @@ public class ByteArrayInputStream extends InputStream {
             if (blockLength == 0) {
                 return -1;
             }
+        }
+        int read = inputStream.read();
+        if (read != -1 && blockLength != -1) {
             blockLength--;
         }
-        return inputStream.read();
+        return read;
     }
 
     @Override
@@ -276,7 +279,7 @@ public class ByteArrayInputStream extends InputStream {
             return -1;
         }
 
-        int read = inputStream.read(b, off, Math.min(len, blockLength));
+        int read = inputStream.read(b, off, (int) Math.min((long) len, blockLength));
         if (read > 0) {
             blockLength -= read;
         }
@@ -289,6 +292,10 @@ public class ByteArrayInputStream extends InputStream {
     }
 
     public void enterBlock(int length) {
+        enterBlock((long) length);
+    }
+
+    public void enterBlock(long length) {
         this.blockLength = length < -1 ? -1 : length;
         this.initialBlockLength = length;
     }
@@ -301,6 +308,10 @@ public class ByteArrayInputStream extends InputStream {
     }
 
     public int getPosition() {
+        return pos > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) pos;
+    }
+
+    public long getLongPosition() {
         return pos;
     }
 
@@ -334,12 +345,15 @@ public class ByteArrayInputStream extends InputStream {
         long skipOf = n;
         if (blockLength != -1) {
             skipOf = Math.min(blockLength, skipOf);
-            blockLength -= skipOf;
+        }
+        long skipped = inputStream.skip(skipOf);
+        if (blockLength != -1) {
+            blockLength -= skipped;
             if (blockLength == 0) {
                 blockLength = -1;
             }
         }
-        pos += (int) skipOf;
-        return inputStream.skip(skipOf);
+        pos += skipped;
+        return skipped;
      }
 }

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientTest.java
@@ -15,10 +15,20 @@
  */
 package com.github.shyiko.mysql.binlog;
 
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.GtidEventData;
+import com.github.shyiko.mysql.binlog.event.MySqlGtid;
+import com.github.shyiko.mysql.binlog.event.XidEventData;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.event.deserialization.TransactionPayloadEventDataDeserializer;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 import com.github.shyiko.mysql.binlog.jmx.BinaryLogClientStatistics;
 import com.github.shyiko.mysql.binlog.network.SocketFactory;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,6 +36,10 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -37,6 +51,8 @@ import static org.testng.Assert.assertTrue;
  * @author <a href="mailto:stanley.shyiko@gmail.com">Stanley Shyiko</a>
  */
 public class BinaryLogClientTest {
+
+    private static final String SERVER_UUID = "24bc7850-2c16-11e6-a073-0242ac110002";
 
     @Test
     public void testEventListenersManagement() {
@@ -113,6 +129,71 @@ public class BinaryLogClientTest {
         new BinaryLogClient("localhost", 3306, "root", "mysql").setEventDeserializer(null);
     }
 
+    @Test
+    public void testTransactionPayloadNotifiesInnerEvents() throws IOException {
+        BinaryLogClient binaryLogClient = new BinaryLogClient("localhost", 3306, "root", "mysql");
+        final List<Event> notifiedEvents = new ArrayList<Event>();
+        binaryLogClient.registerEventListener(new BinaryLogClient.EventListener() {
+            @Override
+            public void onEvent(Event event) {
+                notifiedEvents.add(event);
+            }
+        });
+
+        // The deserializer unpacks the TRANSACTION_PAYLOAD into its inner events before they reach the
+        // client, so the client sees ordinary events - here two XIDs restamped with the outer envelope's
+        // coordinates (event-length and next-position), as getBinlogPosition() relies on.
+        byte[] payloadEvent = transactionPayloadEventBytes(12345L, xidEventBytes(111L), xidEventBytes(222L));
+        feedThroughDeserializer(binaryLogClient, payloadEvent);
+
+        assertEquals(notifiedEvents.size(), 2);
+        assertEquals(notifiedEvents.get(0).getHeader().getEventType(), EventType.XID);
+        assertEquals(((XidEventData) notifiedEvents.get(0).getData()).getXid(), 111L);
+        assertEquals(((XidEventData) notifiedEvents.get(1).getData()).getXid(), 222L);
+
+        EventHeaderV4 firstHeader = notifiedEvents.get(0).getHeader();
+        assertEquals(firstHeader.getEventLength(), (long) payloadEvent.length);
+        assertEquals(firstHeader.getNextPosition(), 12345L);
+        assertEquals(firstHeader.getPosition(), 12345L - payloadEvent.length);
+        assertEquals(binaryLogClient.getBinlogPosition(), 12345L);
+    }
+
+    @Test
+    public void testGtidSetAdvancesWhenCompressedTransactionCommitsInsidePayload() throws IOException {
+        BinaryLogClient binaryLogClient = new BinaryLogClient("localhost", 3306, "root", "mysql");
+        binaryLogClient.setGtidSet(SERVER_UUID + ":1-5");
+
+        binaryLogClient.handleEvent(gtidEvent(6));
+        assertEquals(binaryLogClient.getGtidSet(), SERVER_UUID + ":1-5");
+
+        // The commit (XID) lives inside the compressed payload; once unpacked it advances the gtid set
+        // through the same path a standalone XID would.
+        feedThroughDeserializer(binaryLogClient, transactionPayloadEventBytes(12345L, xidEventBytes(31L)));
+        assertEquals(binaryLogClient.getGtidSet(), SERVER_UUID + ":1-6");
+
+        binaryLogClient.handleEvent(gtidEvent(7));
+        feedThroughDeserializer(binaryLogClient, transactionPayloadEventBytes(12945L, xidEventBytes(32L)));
+        assertEquals(binaryLogClient.getGtidSet(), SERVER_UUID + ":1-7");
+    }
+
+    @Test
+    public void testPacketPayloadInputStreamReadsAcrossSplitPackets() throws IOException {
+        ByteArrayOutputStream wire = new ByteArrayOutputStream();
+        wire.write(new byte[] {1, 2, 3}); // bytes remaining in the first full packet after the marker
+        writeInteger(wire, 2, 3);         // continuation packet length
+        wire.write(7);                    // continuation packet sequence
+        wire.write(new byte[] {4, 5});
+
+        InputStream payloadInputStream = new BinaryLogClient.PacketPayloadInputStream(
+            new ByteArrayInputStream(wire.toByteArray()), 3, true);
+        byte[] result = new byte[5];
+
+        assertEquals(payloadInputStream.read(result, 0, 4), 3);
+        assertEquals(payloadInputStream.read(result, 3, 2), 2);
+        assertEquals(payloadInputStream.read(), -1);
+        assertEquals(result, new byte[] {1, 2, 3, 4, 5});
+    }
+
     @Test(timeOut = 15000)
     public void testDisconnectWhileBlockedByFBRead() throws Exception {
         final BinaryLogClient binaryLogClient = new BinaryLogClient("localhost", 33061, "root", "mysql");
@@ -175,6 +256,102 @@ public class BinaryLogClientTest {
         } catch (IOException e) {
             assertEquals(readAttempted.getCount(), 0);
             assertTrue(e.getMessage().contains("Failed to connect to MySQL"));
+        }
+    }
+
+    private Event gtidEvent(long transactionId) {
+        EventHeaderV4 header = new EventHeaderV4();
+        header.setEventType(EventType.GTID);
+        return new Event(header, new GtidEventData(
+            MySqlGtid.fromString(SERVER_UUID + ":" + transactionId),
+            (byte) 0, 0L, 0L, 0L, 0L, 0L, 0, 0
+        ));
+    }
+
+    // The on-the-wire bytes of a standalone XID event (19-byte v4 header + 8-byte xid), as they
+    // appear inside an (uncompressed) transaction payload. Inner events carry no checksum.
+    private static final int XID_EVENT_TYPE_CODE = 16;
+    private static final int TRANSACTION_PAYLOAD_EVENT_TYPE_CODE = 40;
+
+    private byte[] xidEventBytes(long xid) {
+        ByteBuffer buf = ByteBuffer.allocate(27).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putInt(1000);                       // timestamp
+        buf.put((byte) XID_EVENT_TYPE_CODE);    // event type
+        buf.putInt(1);                          // server id
+        buf.putInt(27);                         // event length
+        buf.putInt(0);                          // next position
+        buf.putShort((short) 0);                // flags
+        buf.putLong(xid);
+        return buf.array();
+    }
+
+    // The on-the-wire bytes of a TRANSACTION_PAYLOAD event (19-byte v4 header + OTW payload header +
+    // an uncompressed body of inner events), as the deserializer reads them off the stream. Building a
+    // COMPRESSION_TYPE_NONE payload drives the same unpack path the deserializer uses for real zstd
+    // payloads, without pulling in a compressor. The header's event-length is the full event size, so
+    // the returned array's length equals getEventLength() (there is no checksum).
+    private byte[] transactionPayloadEventBytes(long nextPosition, byte[]... innerEvents) {
+        ByteArrayOutputStream inner = new ByteArrayOutputStream();
+        for (byte[] innerEvent : innerEvents) {
+            inner.write(innerEvent, 0, innerEvent.length);
+        }
+        byte[] payload = inner.toByteArray();
+
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        writeOtwField(body, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_COMPRESSION_TYPE_FIELD,
+            TransactionPayloadEventDataDeserializer.COMPRESSION_TYPE_NONE);
+        writeOtwField(body, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD,
+            payload.length);
+        writeOtwField(body, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_SIZE_FIELD, payload.length);
+        body.write(TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_HEADER_END_MARK);
+        body.write(payload, 0, payload.length);
+        byte[] bodyBytes = body.toByteArray();
+
+        ByteBuffer header = ByteBuffer.allocate(19).order(ByteOrder.LITTLE_ENDIAN);
+        header.putInt(1000);                                        // timestamp
+        header.put((byte) TRANSACTION_PAYLOAD_EVENT_TYPE_CODE);     // event type
+        header.putInt(1);                                           // server id
+        header.putInt(19 + bodyBytes.length);                       // event length (header + body)
+        header.putInt((int) nextPosition);                          // next position
+        header.putShort((short) 0);                                 // flags
+
+        ByteArrayOutputStream event = new ByteArrayOutputStream();
+        event.write(header.array(), 0, header.array().length);
+        event.write(bodyBytes, 0, bodyBytes.length);
+        return event.toByteArray();
+    }
+
+    private static void writeOtwField(ByteArrayOutputStream out, int fieldType, int value) {
+        writePacked(out, fieldType);
+        writePacked(out, value < 251 ? 1 : 3); // field length, ignored by the deserializer for known fields
+        writePacked(out, value);
+    }
+
+    private static void writePacked(ByteArrayOutputStream out, int value) {
+        if (value < 251) {
+            out.write(value);
+        } else {
+            out.write(0xFC);
+            out.write(value & 0xFF);
+            out.write((value >> 8) & 0xFF);
+        }
+    }
+
+    private static void writeInteger(ByteArrayOutputStream out, int value, int length) {
+        for (int i = 0; i < length; i++) {
+            out.write((value >> (8 * i)) & 0xFF);
+        }
+    }
+
+    // Drives the bytes of one or more events through a real EventDeserializer (which transparently
+    // unpacks any TRANSACTION_PAYLOAD) and hands each resulting event to the client, exactly as the
+    // read loop does.
+    private static void feedThroughDeserializer(BinaryLogClient client, byte[] eventBytes) throws IOException {
+        EventDeserializer deserializer = new EventDeserializer();
+        ByteArrayInputStream stream = new ByteArrayInputStream(eventBytes);
+        Event event;
+        while ((event = deserializer.nextEvent(stream)) != null) {
+            client.handleEvent(event);
         }
     }
 

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogFileReaderIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogFileReaderIntegrationTest.java
@@ -26,6 +26,8 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 import static org.testng.Assert.assertEquals;
@@ -50,7 +52,21 @@ public class BinaryLogFileReaderIntegrationTest {
     public void testNextEventCompressed() throws Exception {
         BinaryLogFileReader reader = new BinaryLogFileReader(
             new FileInputStream("src/test/resources/mysql-bin.compressed"));
-        readAll(reader, 5);
+        try {
+            List<EventType> types = new ArrayList<EventType>();
+            for (Event event; (event = reader.readEvent()) != null; ) {
+                types.add(event.getHeader().getEventType());
+            }
+            // The single TRANSACTION_PAYLOAD wrapper is unpacked transparently, so its inner events
+            // (BEGIN / TABLE_MAP / row change / XID) surface individually rather than as one opaque,
+            // compressed blob - five top-level events become eight.
+            assertEquals(types.size(), 8);
+            assertFalse(types.contains(EventType.TRANSACTION_PAYLOAD));
+            assertTrue(types.contains(EventType.EXT_UPDATE_ROWS));
+            assertTrue(types.contains(EventType.XID));
+        } finally {
+            reader.close();
+        }
     }
 
     @Test

--- a/src/test/java/com/github/shyiko/mysql/binlog/TransactionPayloadIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/TransactionPayloadIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.github.shyiko.mysql.binlog;
 
-import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventType;
-import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
 import com.github.shyiko.mysql.binlog.event.WriteRowsEventData;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -112,48 +110,25 @@ public class TransactionPayloadIntegrationTest extends AbstractIntegrationTest {
             long insertTime = System.currentTimeMillis() - startTime;
             System.out.println("Transaction committed in " + (insertTime / 1000) + " seconds");
 
-            // Wait for transaction payload event (give it more time for large transactions)
+            // With streaming unwrap the TRANSACTION_PAYLOAD wrapper is never delivered to listeners;
+            // its inner events are re-emitted individually. Wait for the transaction's commit (XID),
+            // the last inner event of the payload.
             long largeTimeout = BinaryLogClientIntegrationTest.DEFAULT_TIMEOUT * 1000; // 30 seconds
-            eventListener.waitFor(EventType.TRANSACTION_PAYLOAD, 1, largeTimeout);
+            eventListener.waitFor(EventType.XID, 1, largeTimeout);
 
-            // Verify the large payload was handled correctly
-            List<TransactionPayloadEventData> payloadEvents =
-                capturingEventListener.getEvents(TransactionPayloadEventData.class);
+            // Every inserted row must arrive as an inner WRITE_ROWS event, proving the >1GB
+            // transaction was decompressed and delivered incrementally rather than materialized whole
+            // (which would exceed the 2GB byte[] limit / exhaust the heap).
+            List<WriteRowsEventData> writeRowsEvents =
+                capturingEventListener.getEvents(WriteRowsEventData.class);
+            assertFalse(writeRowsEvents.isEmpty(), "streaming unwrap should deliver inner WRITE_ROWS events");
 
-            assertTrue(payloadEvents.size() > 0, "Should have captured TRANSACTION_PAYLOAD event");
-
-            TransactionPayloadEventData payloadEventData = payloadEvents.get(0);
-            assertNotNull(payloadEventData, "TRANSACTION_PAYLOAD event data should not be null");
-
-            long uncompressedSize = payloadEventData.getUncompressedSize();
-            long compressedSize = payloadEventData.getPayloadSize();
-
-            // Validate sizes
-            assertTrue(compressedSize > 0, "Compressed size should be > 0");
-            assertTrue(compressedSize < Integer.MAX_VALUE,
-                "Compressed size must be < 2GB (Java array limit): " + compressedSize);
-            assertTrue(uncompressedSize > 1024L * 1024 * 1024,
-                "Uncompressed size should be > 1GB: " + (uncompressedSize / (1024 * 1024)) + " MB");
-
-            // Verify compression ratio
-            double compressionRatio = (double) uncompressedSize / compressedSize;
-            assertTrue(compressionRatio > 2.0,
-                "Should have good compression ratio (>2x) for repetitive data, got: " +
-                String.format("%.2fx", compressionRatio));
-
-            // Verify all events were decompressed successfully via streaming
-            List<Event> uncompressedEvents = payloadEventData.getUncompressedEvents();
-            assertNotNull(uncompressedEvents, "Should have uncompressed events");
-            assertFalse(uncompressedEvents.isEmpty(), "Should have decompressed events successfully");
-
-            // Count WriteRowsEventData events
-            int writeRowsCount = 0;
-            for (Event event : uncompressedEvents) {
-                if (event.getData() instanceof WriteRowsEventData) {
-                    writeRowsCount++;
-                }
+            int rowCount = 0;
+            for (WriteRowsEventData writeRows : writeRowsEvents) {
+                rowCount += writeRows.getRows().size();
             }
-            assertTrue(writeRowsCount > 0, "Should have WriteRowsEventData in the payload");
+            assertEquals(rowCount, numRows,
+                "all inserted rows should be delivered via streaming unwrap, got " + rowCount);
 
             long totalTime = System.currentTimeMillis() - startTime;
 
@@ -161,14 +136,8 @@ public class TransactionPayloadIntegrationTest extends AbstractIntegrationTest {
             System.out.printf("Rows inserted: %d%n", numRows);
             System.out.printf("Estimated uncompressed data: ~%d MB%n",
                 ((long) numRows * 3 * chunk.length()) / (1024 * 1024));
-            System.out.printf("Actual uncompressed size: %d MB%n",
-                uncompressedSize / (1024 * 1024));
-            System.out.printf("Compressed size: %.2f MB (%.1f%% of limit)%n",
-                compressedSize / (1024.0 * 1024.0),
-                (compressedSize * 100.0 / Integer.MAX_VALUE));
-            System.out.printf("Compression ratio: %.2fx%n", compressionRatio);
-            System.out.printf("Events decompressed: %d%n", uncompressedEvents.size());
-            System.out.printf("Write events: %d%n", writeRowsCount);
+            System.out.printf("WRITE_ROWS events delivered: %d%n", writeRowsEvents.size());
+            System.out.printf("Rows delivered: %d%n", rowCount);
             System.out.printf("Total time: %.1f seconds%n", totalTime / 1000.0);
             System.out.println("===========================================\n");
 

--- a/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TransactionPayloadEventDataDeserializerTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/event/deserialization/TransactionPayloadEventDataDeserializerTest.java
@@ -15,15 +15,27 @@
  */
 package com.github.shyiko.mysql.binlog.event.deserialization;
 
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
 import com.github.shyiko.mysql.binlog.event.EventType;
 import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
-import com.github.shyiko.mysql.binlog.event.XAPrepareEventData;
+import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
+import com.github.shyiko.mysql.binlog.event.XidEventData;
 import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:somesh.malviya@booking.com">Somesh Malviya</a>
@@ -71,6 +83,7 @@ public class TransactionPayloadEventDataDeserializerTest {
     private static final int PAYLOAD_SIZE = 451;
     private static final int UNCOMPRESSED_SIZE = 960;
     private static final int NUMBER_OF_UNCOMPRESSED_EVENTS = 4;
+    private static final int XID_EVENT_TYPE_CODE = 16;
     private static final String UNCOMPRESSED_UPDATE_EVENT =
       new StringBuilder()
           .append(
@@ -90,11 +103,258 @@ public class TransactionPayloadEventDataDeserializerTest {
           assertEquals(COMPRESSION_TYPE, transactionPayloadEventData.getCompressionType());
           assertEquals(PAYLOAD_SIZE, transactionPayloadEventData.getPayloadSize());
           assertEquals(UNCOMPRESSED_SIZE, transactionPayloadEventData.getUncompressedSize());
-          assertEquals(NUMBER_OF_UNCOMPRESSED_EVENTS, transactionPayloadEventData.getUncompressedEvents().size());
-          assertEquals(EventType.QUERY, transactionPayloadEventData.getUncompressedEvents().get(0).getHeader().getEventType());
-          assertEquals(EventType.TABLE_MAP, transactionPayloadEventData.getUncompressedEvents().get(1).getHeader().getEventType());
-          assertEquals(EventType.EXT_UPDATE_ROWS, transactionPayloadEventData.getUncompressedEvents().get(2).getHeader().getEventType());
-          assertEquals(EventType.XID, transactionPayloadEventData.getUncompressedEvents().get(3).getHeader().getEventType());
-          assertEquals(UNCOMPRESSED_UPDATE_EVENT, transactionPayloadEventData.getUncompressedEvents().get(2).getData().toString());
+          // Inner events are streamed lazily, not materialized on the event data.
+          assertTrue(transactionPayloadEventData.getUncompressedEvents().isEmpty());
+          List<Event> innerEvents = drain(deserializer.iterator(transactionPayloadEventData));
+          assertEquals(NUMBER_OF_UNCOMPRESSED_EVENTS, innerEvents.size());
+          assertEquals(EventType.QUERY, innerEvents.get(0).getHeader().getEventType());
+          assertEquals(EventType.TABLE_MAP, innerEvents.get(1).getHeader().getEventType());
+          assertEquals(EventType.EXT_UPDATE_ROWS, innerEvents.get(2).getHeader().getEventType());
+          assertEquals(EventType.XID, innerEvents.get(3).getHeader().getEventType());
+          assertEquals(UNCOMPRESSED_UPDATE_EVENT, innerEvents.get(2).getData().toString());
+    }
+
+    @Test
+    public void deserializeUncompressedPayload() throws IOException {
+        byte[] innerEvent = xidEventBytes(123L);
+        byte[] body = payloadEventBody(
+            TransactionPayloadEventDataDeserializer.COMPRESSION_TYPE_NONE, null, innerEvent);
+        TransactionPayloadEventDataDeserializer deserializer = new TransactionPayloadEventDataDeserializer();
+
+        TransactionPayloadEventData transactionPayloadEventData =
+            deserializer.deserialize(new ByteArrayInputStream(body));
+
+        assertEquals(TransactionPayloadEventDataDeserializer.COMPRESSION_TYPE_NONE,
+            transactionPayloadEventData.getCompressionType());
+        assertEquals(innerEvent.length, transactionPayloadEventData.getUncompressedSize());
+        List<Event> innerEvents = drain(deserializer.iterator(transactionPayloadEventData));
+        assertEquals(1, innerEvents.size());
+        assertEquals(123L, ((XidEventData) innerEvents.get(0).getData()).getXid());
+    }
+
+    @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Unsupported.*")
+    public void deserializeUnsupportedCompressionType() throws IOException {
+        TransactionPayloadEventDataDeserializer deserializer = new TransactionPayloadEventDataDeserializer();
+        deserializer.deserialize(new ByteArrayInputStream(payloadEventBody(42, 27, new byte[] {1, 2, 3})));
+    }
+
+    @Test
+    public void deserializeAllowsCompressedPayloadSizeGreaterThanJavaArrayLimit() throws IOException {
+        long payloadSize = (long) Integer.MAX_VALUE + 5L;
+        TransactionPayloadEventDataDeserializer deserializer = new TransactionPayloadEventDataDeserializer();
+
+        TransactionPayloadEventData transactionPayloadEventData =
+            deserializer.deserialize(new ByteArrayInputStream(payloadEventBodyHeaderOnly(
+                TransactionPayloadEventDataDeserializer.COMPRESSION_TYPE_NONE, null, payloadSize)));
+
+        assertEquals(transactionPayloadEventData.getPayloadSizeLong(), payloadSize);
+        assertEquals(transactionPayloadEventData.getUncompressedSize(), payloadSize);
+        assertNull(transactionPayloadEventData.getPayload());
+        assertNotNull(transactionPayloadEventData.getPayloadInputStream());
+    }
+
+    @Test
+    public void deserializeAppliesCompatibilityModesToInnerEvents() throws IOException {
+        TransactionPayloadEventDataDeserializer deserializer = new TransactionPayloadEventDataDeserializer();
+        EventDeserializer outerDeserializer = new EventDeserializer();
+        outerDeserializer.setEventDataDeserializer(EventType.TRANSACTION_PAYLOAD, deserializer);
+        outerDeserializer.setCompatibilityMode(EventDeserializer.CompatibilityMode.CHAR_AND_BINARY_AS_BYTE_ARRAY);
+
+        TransactionPayloadEventData transactionPayloadEventData =
+            deserializer.deserialize(new ByteArrayInputStream(DATA));
+        List<Event> innerEvents = drain(deserializer.iterator(transactionPayloadEventData));
+        UpdateRowsEventData updateRowsEventData =
+            (UpdateRowsEventData) innerEvents.get(2).getData();
+
+        assertTrue(updateRowsEventData.getRows().get(0).getValue()[1] instanceof byte[]);
+    }
+
+    @Test
+    public void nextEventTransparentlyUnpacksAndRestampsInnerEvents() throws IOException {
+        EventDeserializer eventDeserializer = new EventDeserializer();
+        // A TRANSACTION_PAYLOAD (next-position 12345) wrapping two XIDs, followed by a standalone XID,
+        // so we also prove the stream stays aligned once the payload's inner events have been drained.
+        byte[] payloadEvent = transactionPayloadEvent(12345L, xidEventBytes(111L), xidEventBytes(222L));
+        ByteArrayInputStream stream = new ByteArrayInputStream(concat(payloadEvent, xidEventBytes(333L)));
+
+        List<Event> events = new ArrayList<Event>();
+        Event event;
+        while ((event = eventDeserializer.nextEvent(stream)) != null) {
+            events.add(event);
+        }
+
+        assertEquals(3, events.size());
+        assertEquals(EventType.XID, events.get(0).getHeader().getEventType());
+        assertEquals(111L, ((XidEventData) events.get(0).getData()).getXid());
+        assertEquals(222L, ((XidEventData) events.get(1).getData()).getXid());
+        assertEquals(333L, ((XidEventData) events.get(2).getData()).getXid());
+
+        // Inner events are restamped with the outer envelope's coordinates...
+        EventHeaderV4 firstInner = (EventHeaderV4) events.get(0).getHeader();
+        assertEquals((long) payloadEvent.length, firstInner.getEventLength());
+        assertEquals(12345L, firstInner.getNextPosition());
+        // ...while the standalone event read after the payload keeps its own (default 27 / 0).
+        assertEquals(27L, ((EventHeaderV4) events.get(2).getHeader()).getEventLength());
+        assertFalse(eventDeserializer.hasPendingTransactionPayloadEvent());
+    }
+
+    @Test
+    public void nextEventDoesNotPrefetchNextInnerEvent() throws IOException {
+        EventDeserializer eventDeserializer = new EventDeserializer();
+        byte[] firstInnerEvent = xidEventBytes(111L);
+        byte[] secondInnerEvent = xidEventBytes(222L);
+        byte[] payloadEvent = transactionPayloadEvent(12345L, firstInnerEvent, secondInnerEvent);
+        ByteArrayInputStream stream = new ByteArrayInputStream(payloadEvent);
+
+        Event firstEvent = eventDeserializer.nextEvent(stream);
+
+        assertEquals(EventType.XID, firstEvent.getHeader().getEventType());
+        assertEquals(111L, ((XidEventData) firstEvent.getData()).getXid());
+        assertEquals(stream.getLongPosition(), payloadEvent.length - secondInnerEvent.length);
+        assertTrue(eventDeserializer.hasPendingTransactionPayloadEvent());
+
+        Event secondEvent = eventDeserializer.nextEvent(stream);
+
+        assertEquals(EventType.XID, secondEvent.getHeader().getEventType());
+        assertEquals(222L, ((XidEventData) secondEvent.getData()).getXid());
+        assertEquals(stream.getLongPosition(), payloadEvent.length);
+        assertFalse(eventDeserializer.hasPendingTransactionPayloadEvent());
+    }
+
+    private static List<Event> drain(TransactionPayloadEventDataDeserializer.InnerEventIterator iterator)
+            throws IOException {
+        List<Event> events = new ArrayList<Event>();
+        try {
+            Event event;
+            while ((event = iterator.next()) != null) {
+                events.add(event);
+            }
+        } finally {
+            iterator.close();
+        }
+        return events;
+    }
+
+    private static byte[] xidEventBytes(long xid) {
+        ByteBuffer buf = ByteBuffer.allocate(27).order(ByteOrder.LITTLE_ENDIAN);
+        buf.putInt(1000);
+        buf.put((byte) XID_EVENT_TYPE_CODE);
+        buf.putInt(1);
+        buf.putInt(27);
+        buf.putInt(0);
+        buf.putShort((short) 0);
+        buf.putLong(xid);
+        return buf.array();
+    }
+
+    private static final int TRANSACTION_PAYLOAD_EVENT_TYPE_CODE = 40;
+
+    // The full on-the-wire bytes of a TRANSACTION_PAYLOAD event (19-byte v4 header + OTW payload header
+    // + uncompressed inner events). The header's event-length is the full event size, so the returned
+    // array's length equals getEventLength() (there is no checksum).
+    private static byte[] transactionPayloadEvent(long nextPosition, byte[]... innerEvents) {
+        ByteArrayOutputStream inner = new ByteArrayOutputStream();
+        for (byte[] innerEvent : innerEvents) {
+            inner.write(innerEvent, 0, innerEvent.length);
+        }
+        byte[] payload = inner.toByteArray();
+        byte[] body = payloadEventBody(
+            TransactionPayloadEventDataDeserializer.COMPRESSION_TYPE_NONE, payload.length, payload);
+
+        ByteBuffer header = ByteBuffer.allocate(19).order(ByteOrder.LITTLE_ENDIAN);
+        header.putInt(1000);                                    // timestamp
+        header.put((byte) TRANSACTION_PAYLOAD_EVENT_TYPE_CODE); // event type
+        header.putInt(1);                                       // server id
+        header.putInt(19 + body.length);                        // event length (header + body)
+        header.putInt((int) nextPosition);                      // next position
+        header.putShort((short) 0);                             // flags
+        return concat(header.array(), body);
+    }
+
+    private static byte[] concat(byte[]... arrays) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] array : arrays) {
+            out.write(array, 0, array.length);
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] payloadEventBody(Integer compressionType, Integer uncompressedSize, byte[] payload) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        if (compressionType != null) {
+            writePacked(out, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_COMPRESSION_TYPE_FIELD);
+            writePacked(out, packedLength(compressionType));
+            writePacked(out, compressionType);
+        }
+        if (uncompressedSize != null) {
+            writePacked(out, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD);
+            writePacked(out, packedLength(uncompressedSize));
+            writePacked(out, uncompressedSize);
+        }
+        writePacked(out, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_SIZE_FIELD);
+        writePacked(out, packedLength(payload.length));
+        writePacked(out, payload.length);
+        out.write(TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_HEADER_END_MARK);
+        out.write(payload, 0, payload.length);
+        return out.toByteArray();
+    }
+
+    private static byte[] payloadEventBodyHeaderOnly(Integer compressionType, Long uncompressedSize,
+            long payloadSize) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        if (compressionType != null) {
+            writePacked(out, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_COMPRESSION_TYPE_FIELD);
+            writePacked(out, packedLength(compressionType));
+            writePacked(out, compressionType);
+        }
+        if (uncompressedSize != null) {
+            writePacked(out, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_UNCOMPRESSED_SIZE_FIELD);
+            writePacked(out, packedLength(uncompressedSize));
+            writePacked(out, uncompressedSize);
+        }
+        writePacked(out, TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_SIZE_FIELD);
+        writePacked(out, packedLength(payloadSize));
+        writePacked(out, payloadSize);
+        out.write(TransactionPayloadEventDataDeserializer.OTW_PAYLOAD_HEADER_END_MARK);
+        return out.toByteArray();
+    }
+
+    private static void writePacked(ByteArrayOutputStream out, int value) {
+        writePacked(out, (long) value);
+    }
+
+    private static void writePacked(ByteArrayOutputStream out, long value) {
+        if (value < 251) {
+            out.write((int) value);
+        } else if (value <= 0xFFFFL) {
+            out.write(0xFC);
+            out.write((int) (value & 0xFF));
+            out.write((int) ((value >> 8) & 0xFF));
+        } else if (value <= 0xFFFFFFL) {
+            out.write(0xFD);
+            out.write((int) (value & 0xFF));
+            out.write((int) ((value >> 8) & 0xFF));
+            out.write((int) ((value >> 16) & 0xFF));
+        } else {
+            out.write(0xFE);
+            for (int i = 0; i < 8; i++) {
+                out.write((int) ((value >> (8 * i)) & 0xFF));
+            }
+        }
+    }
+
+    private static int packedLength(int value) {
+        return packedLength((long) value);
+    }
+
+    private static int packedLength(long value) {
+        if (value < 251) {
+            return 1;
+        } else if (value <= 0xFFFFL) {
+            return 3;
+        } else if (value <= 0xFFFFFFL) {
+            return 4;
+        }
+        return 9;
     }
 }


### PR DESCRIPTION
Refactor of #177 with a cleaner structure (supersedes it).

Transparently unpacks `TRANSACTION_PAYLOAD` events (ZSTD / NONE) and re-emits their
inner events as ordinary top-level events, so consumers keep seeing `QUERY`,
`TABLE_MAP`, row and commit events. Decompression is streamed/iterated with bounded
memory, so a transaction whose compressed or uncompressed image exceeds the 2GB
`byte[]` limit (or spans 16MB packets) is handled.

### What changed vs #177
The per-payload streaming state machine no longer lives inline in `EventDeserializer`.
It moved into a dedicated **`TransactionPayloadEventBuffer`** held by `EventDeserializer`:
`nextEvent()` simply drains the buffer (`hasPending()` / `next()`) before reading the
stream, and hands a `TRANSACTION_PAYLOAD` off via `open(...)`. This shrank
`EventDeserializer`'s diff vs master from +211 to +38 lines.

Also: a custom `TRANSACTION_PAYLOAD` deserializer now falls back to whole-payload
materialization (previously it threw).

### Tests
Contract + unit tests pass, including the end-to-end `BinaryLogFileReaderIntegrationTest`
decoding the real `mysql-bin.compressed` resource (5 → 8 top-level events, no
`TRANSACTION_PAYLOAD` leaking through), no-prefetch streaming, restamped inner-event
coordinates, >2GB payload handling, and cross-packet reads. The MySQL-backed
integration tests need a live server to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
